### PR TITLE
Split verifier is removed as of JDK8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.10</version>
 				<configuration>
-					<argLine>-XX:-UseSplitVerifier</argLine>
+					<argLine>-noverify</argLine>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Running the tests with the (now current) JDK8 results in bytecode verification errors. The use of `-XX:-UseSplitVerifier` mitigated this up till JDK7. However, it has been removed in JDK8. Use `-noverify` to achieve the same effect.
