### PR TITLE
fix for Issue#22

### DIFF
--- a/src/main/java/com/microsoft/aad/adal4j/AdalAuthorizatonGrant.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AdalAuthorizatonGrant.java
@@ -63,11 +63,7 @@ class AdalAuthorizatonGrant {
             outParams.putAll(this.params);
         }
         
-        if(!outParams.containsKey("scope"))
-        {
-        	outParams.put("scope", "openid");
-        }
-        
+        outParams.put("scope", "openid");
         outParams.putAll(grant.toParameters());
         return outParams;
     }

--- a/src/main/java/com/microsoft/aad/adal4j/AdalAuthorizatonGrant.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AdalAuthorizatonGrant.java
@@ -62,6 +62,12 @@ class AdalAuthorizatonGrant {
         if (this.params != null) {
             outParams.putAll(this.params);
         }
+        
+        if(!outParams.containsKey("scope"))
+        {
+        	outParams.put("scope", "openid");
+        }
+        
         outParams.putAll(grant.toParameters());
         return outParams;
     }


### PR DESCRIPTION
Fix for
https://github.com/AzureAD/azure-activedirectory-library-for-java/issues
/22
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/RandalliLama%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23issuecomment-99221076%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-05-05T21%3A04%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2095d6c415fba46fbcbc8b6a263dcb65c04423eb2a%20src/main/java/com/microsoft/aad/adal4j/AdalAuthorizatonGrant.java%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23discussion_r29710346%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20scope%20parameter%20is%20multi-valued.%20%20Could%20we%20just%20add%20openid%20to%20the%20end%20if%20it%27s%20not%20already%20there%3F%22%2C%20%22created_at%22%3A%20%222015-05-05T20%3A39%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22ADAL%20.NET%20behaves%20just%20like%20this%20where%20it%20simply%20assigns%20scope%3Dopenid.%20We%20also%20do%20not%20allow%20scopes%20to%20be%20set%20by%20the%20user.%20I%20do%20not%20see%20the%20case/need%20to%20deal%20with%20multi%20scope%20value.%20what%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222015-05-05T20%3A44%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20we%20don%27t%20allow%20scope%20to%20be%20set%2C%20why%20are%20you%20checking%20to%20see%20if%20it%20is%20set%20in%20this%20code%20path.%20%20You%20only%20set%20scope%20to%20openid%20if%20it%20wasn%27t%20already%20set.%20%20I%20would%20have%20assumed%20that%20there%20should%20be%20no%20way%20that%20it%20would%20have%20been%20set%20at%20this%20point.%20%20And%20if%20it%20was%2C%20then%20we%20need%20to%20figure%20out%20what%20to%20do%20about%20that.%20%20Dropping%20the%20openid%20value%20is%20not%20an%20obvious%20course%20of%20action%20to%20me.%22%2C%20%22created_at%22%3A%20%222015-05-05T20%3A51%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22Are%20you%20checking%20for%20scope%20as%20part%20of%20incoming%20parameter%20validation%20in%20the%20extraQueryParameters%20parameter%3F%22%2C%20%22created_at%22%3A%20%222015-05-05T20%3A54%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22good%20point.%20I%20can%20remove%20the%20if%20contains%20check.%20sounds%20good%3F%22%2C%20%22created_at%22%3A%20%222015-05-05T20%3A54%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sounds%20good%2C%20but%20I%20also%20want%20to%20know%20whether%20you%20are%20enforcing%2C%20%5C%22We%20also%20do%20not%20allow%20scopes%20to%20be%20set%20by%20the%20user.%5C%22%22%2C%20%22created_at%22%3A%20%222015-05-05T20%3A55%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22there%20are%20no%20extra%20QP%20supported%20on%20token%20endpoint.%20remove%20the%20if%20contains%20check%20is%20the%20way%20to%20go.%22%2C%20%22created_at%22%3A%20%222015-05-05T20%3A56%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%2C%20%7B%22body%22%3A%20%22API%20surface%20does%20not%20allow%20for%20extra%20query%20parameters%20or%20scope%20explicitly%20being%20passed%20in.%22%2C%20%22created_at%22%3A%20%222015-05-05T20%3A57%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20the%20important%20thing%20is%20that%20there%20are%20no%20extra%20QP%20allowed%20in%20the%20username%20password%20overloads%20%28token%20endpoint%20is%20a%20protocol%20artifact%20that%20is%20involved%20regardless%20of%20the%20overload%29.%20%20%5Cr%5Cn%5Cr%5CnSorry%2C%20I%20can%27t%20help%20being%20pedantic.%20%20%5Cr%5Cn%5Cr%5CnYou%27re%20suggestion%20sounds%20great.%20%20Please%20proceed.%22%2C%20%22created_at%22%3A%20%222015-05-05T20%3A58%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-05-05T20%3A59%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/com/microsoft/aad/adal4j/AdalAuthorizatonGrant.java%3AL62-74%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23issuecomment-99221076%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23discussion_r29710346%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23discussion_r29710779%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23discussion_r29711541%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23discussion_r29711810%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23discussion_r29711839%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23discussion_r29711983%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23discussion_r29712001%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23discussion_r29712172%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23discussion_r29712192%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/23%23discussion_r29712368%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/RandalliLama'><img src='https://avatars.githubusercontent.com/u/4307330?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-Pull 95d6c415fba46fbcbc8b6a263dcb65c04423eb2a src/main/java/com/microsoft/aad/adal4j/AdalAuthorizatonGrant.java 7'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/23#discussion_r29710346'>File: src/main/java/com/microsoft/aad/adal4j/AdalAuthorizatonGrant.java:L62-74</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> The scope parameter is multi-valued.  Could we just add openid to the end if it's not already there?
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> ADAL .NET behaves just like this where it simply assigns scope=openid. We also do not allow scopes to be set by the user. I do not see the case/need to deal with multi scope value. what do you think?
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> If we don't allow scope to be set, why are you checking to see if it is set in this code path.  You only set scope to openid if it wasn't already set.  I would have assumed that there should be no way that it would have been set at this point.  And if it was, then we need to figure out what to do about that.  Dropping the openid value is not an obvious course of action to me.
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> Are you checking for scope as part of incoming parameter validation in the extraQueryParameters parameter?
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> good point. I can remove the if contains check. sounds good?
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> Sounds good, but I also want to know whether you are enforcing, "We also do not allow scopes to be set by the user."
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> there are no extra QP supported on token endpoint. remove the if contains check is the way to go.
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> API surface does not allow for extra query parameters or scope explicitly being passed in.
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> I think the important thing is that there are no extra QP allowed in the username password overloads (token endpoint is a protocol artifact that is involved regardless of the overload).
Sorry, I can't help being pedantic.
You're suggestion sounds great.  Please proceed.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-java/pull/23?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-java/pull/23?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-java/pull/23?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/23'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>