### PR TITLE
modify xpath search to get ws2005 endpoint. 

### DIFF
--- a/src/main/java/com/microsoft/aad/adal4j/MexParser.java
+++ b/src/main/java/com/microsoft/aad/adal4j/MexParser.java
@@ -63,10 +63,18 @@ class MexParser {
                 mexResponse.getBytes(Charset.forName("UTF-8"))));
 
         XPath xPath = XPathFactory.newInstance().newXPath();
-        xPath.setNamespaceContext(new NamespaceContextImpl());
-        Map<String, BindingPolicy> policies = selectUsernamePasswordPolicies(
-                xmlDocument, xPath);
-
+        NamespaceContextImpl nameSpace = new NamespaceContextImpl();
+        xPath.setNamespaceContext(nameSpace);
+        String xpathExpression = "//wsdl:definitions/wsp:Policy/wsp:ExactlyOne/wsp:All/"
+                 + "sp:SignedEncryptedSupportingTokens/wsp:Policy/sp:UsernameToken/"
+                 + "wsp:Policy/sp:WssUsernameToken10";
+    	Map<String, BindingPolicy> policies = selectUsernamePasswordPoliciesWithExpression(xmlDocument, xPath, xpathExpression);
+        nameSpace.modifyNameSpace("sp", "http://schemas.xmlsoap.org/ws/2005/07/securitypolicy");
+        xpathExpression = "//wsdl:definitions/wsp:Policy/wsp:ExactlyOne/wsp:All/"
+                + "sp:SignedSupportingTokens/wsp:Policy/sp:UsernameToken/"
+                + "wsp:Policy/sp:WssUsernameToken10";
+    	policies.putAll(selectUsernamePasswordPoliciesWithExpression(xmlDocument, xPath, xpathExpression));
+        
         if (policies.isEmpty()) {
             log.debug("No matching policies");
             return null;
@@ -223,11 +231,9 @@ class MexParser {
         return WsTrustVersion.UNDEFINED;
     }
 
-    private static Map<String, BindingPolicy> selectUsernamePasswordPolicies(
-            Document xmlDocument, XPath xPath) throws XPathExpressionException {
-        String xpathExpression = "//wsdl:definitions/wsp:Policy/wsp:ExactlyOne/wsp:All/"
-                + "sp:SignedEncryptedSupportingTokens/wsp:Policy/sp:UsernameToken/"
-                + "wsp:Policy/sp:WssUsernameToken10";
+    private static Map<String, BindingPolicy> selectUsernamePasswordPoliciesWithExpression(
+            Document xmlDocument, XPath xPath, String xpathExpression) throws XPathExpressionException {
+        
         Map<String, BindingPolicy> policies = new HashMap<String, BindingPolicy>();
 
         NodeList nodeList = (NodeList) xPath.compile(xpathExpression).evaluate(

--- a/src/main/java/com/microsoft/aad/adal4j/NamespaceContextImpl.java
+++ b/src/main/java/com/microsoft/aad/adal4j/NamespaceContextImpl.java
@@ -45,6 +45,7 @@ public class NamespaceContextImpl implements NamespaceContext {
         PREF_MAP.put("s", "http://www.w3.org/2003/05/soap-envelope");
         PREF_MAP.put("wsa", "http://www.w3.org/2005/08/addressing");
         PREF_MAP.put("wst", "http://docs.oasis-open.org/ws-sx/ws-trust/200512");
+        PREF_MAP.put("t", "http://schemas.xmlsoap.org/ws/2005/02/trust");
         PREF_MAP.put("a", "http://www.w3.org/2005/08/addressing");
         PREF_MAP.put("q", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
     }

--- a/src/main/java/com/microsoft/aad/adal4j/NamespaceContextImpl.java
+++ b/src/main/java/com/microsoft/aad/adal4j/NamespaceContextImpl.java
@@ -49,6 +49,10 @@ public class NamespaceContextImpl implements NamespaceContext {
         PREF_MAP.put("q", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
     }
 
+    public void modifyNameSpace(String key, String value){
+        PREF_MAP.put(key, value);
+    }
+    
     public String getNamespaceURI(String prefix) {
         return PREF_MAP.get(prefix);
     }

--- a/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
@@ -57,7 +57,7 @@ class WSTrustRequest {
 
         headers.put("SOAPAction", soapAction);
         String body = buildMessage(policy.getUrl(), username, password, policy.getVersion()).toString();
-        String response = HttpHelper.executeHttpPost(log, url, body, headers);
+        String response = HttpHelper.executeHttpPost(log, policy.getUrl(), body, headers);
         return WSTrustResponse.parse(response);
     }
 
@@ -79,7 +79,6 @@ class WSTrustRequest {
         
         if (addressVersion == WsTrustVersion.WSTRUST2005)
         {
-            schemaLocation = "http://schemas.xmlsoap.org/ws/2005/02/trust/ws-trust.xsd";
             soapAction = "http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue";
             rstTrustNamespace = "http://schemas.xmlsoap.org/ws/2005/02/trust";
             keyType = "http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey";
@@ -151,11 +150,6 @@ class WSTrustRequest {
         username = StringEscapeUtils.escapeXml10(username);
         password = StringEscapeUtils.escapeXml10(password);
 
-        messageCredentialsBuilder
-                .append(String
-                        .format("<o:UsernameToken u:Id='uuid-%s'><o:Username>%s</o:Username><o:Password>%s</o:Password></o:UsernameToken>",
-                                guid, username, password));
-
         DateFormat dateFormat = new SimpleDateFormat(
                 "yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
@@ -167,55 +161,25 @@ class WSTrustRequest {
         date = new Date(date.getTime() + toAdd);
         String expiryTimString = dateFormat.format(date);
 
-        if (version == WsTrustVersion.WSTRUST2005) {
-            //<wsse:Security soap:mustUnderstand="1" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
-            //<wsu:Timestamp wsu:Id="TS-1">
-            //<wsu:Created>2014-02-10T23:36:42Z</wsu:Created>
-            //<wsu:Expires>2014-02-10T24:36:42Z</wsu:Expires>
-            //</wsu:Timestamp>
-            //<wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="SecurityToken-6138db82-5a4c-4bf7-915f-af7a10d9ae96">
-            //<wsse:Username>user</wsse:Username>
-            //<wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">CBb7a2itQDgxVkqYnFtggUxtuqk=</wsse:Password>
-            //</wsse:UsernameToken>
-            //</wsse:Security>
-            messageCredentialsBuilder.append(String.format(
-                    "<wsse:UsernameToken xmlns:wsu='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd' wsu:Id='SecurityToken-%s'>" + // guid
-                            "<wsse:Username>%s</wsse:Username>" + // user
-                            "<wsse:Password Type='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest'>%s</wsse:Password>", // password
-                    guid,
-                    username,
-                    password));
+        messageCredentialsBuilder.append(String.format(
+                "<o:UsernameToken u:Id='uuid-"
+                + "%s'>" + // guid
+                "<o:Username>%s</o:Username>" + //username
+                "<o:Password>%s</o:Password>" + //password
+                "</o:UsernameToken>",
+                guid,
+                username,
+                password));
 
-            securityHeaderBuilder.append("<wsse:Security soap:mustUnderstand='1' xmlns:wsse='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' xmlns:wsu='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd'>");
-            securityHeaderBuilder.append(String.format(
-                    "<wsu:Timestamp wsu:Id='uuid-%s'>" +        // guid
-                            "<wsu:Created>%s</wsu:Created>" +        // created
-                            "<wsu:Expires>%s</wsu:Expires>" +        // Expires
-                            "</wsu:Timestamp>",
-                    guid,
-                    currentTimeString, expiryTimString));
-            securityHeaderBuilder.append(String.format("%s</wsse:Security>", messageCredentialsBuilder.toString()));
-        } else if (version == WsTrustVersion.WSTRUST13) {
-            messageCredentialsBuilder.append(String.format(
-                    "<o:UsernameToken u:Id='uuid-" +
-                            "%s'>" + // guid
-                            "<o:Username>%s</o:Username>" + //username
-                            "<o:Password>%s</o:Password>" + //password
-                            "</o:UsernameToken>",
-                    guid,
-                    username,
-                    password));
-
-            securityHeaderBuilder.append("<o:Security s:mustUnderstand='1' xmlns:o='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'>");
-            securityHeaderBuilder.append(String.format(
-                    "<u:Timestamp u:Id='_0'>" +
-                            "<u:Created>%s</u:Created>" +        // created
-                            "<u:Expires>%s</u:Expires>" +        // Expires
-                            "</u:Timestamp>",
-                    currentTimeString, expiryTimString));
-            securityHeaderBuilder.append(messageCredentialsBuilder.toString());
-            securityHeaderBuilder.append("</o:Security>");
-        }
+        securityHeaderBuilder.append("<o:Security s:mustUnderstand='1' xmlns:o='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'>");
+        securityHeaderBuilder.append(String.format(
+                "<u:Timestamp u:Id='_0'>"
+                + "<u:Created>%s</u:Created>" + // created
+                "<u:Expires>%s</u:Expires>" + // Expires
+                "</u:Timestamp>",
+                currentTimeString, expiryTimString));
+        securityHeaderBuilder.append(messageCredentialsBuilder.toString());
+        securityHeaderBuilder.append("</o:Security>");
 
         return securityHeaderBuilder;
     }

--- a/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
@@ -58,7 +58,7 @@ class WSTrustRequest {
         headers.put("SOAPAction", soapAction);
         String body = buildMessage(policy.getUrl(), username, password, policy.getVersion()).toString();
         String response = HttpHelper.executeHttpPost(log, policy.getUrl(), body, headers);
-        return WSTrustResponse.parse(response);
+        return WSTrustResponse.parse(response, policy.getVersion());
     }
 
     private static StringBuilder buildMessage(String address, String username,
@@ -159,7 +159,7 @@ class WSTrustRequest {
         // Expiry is 10 minutes after creation
         int toAdd = 60 * 1000 * 10;
         date = new Date(date.getTime() + toAdd);
-        String expiryTimString = dateFormat.format(date);
+        String expiryTimeString = dateFormat.format(date);
 
         messageCredentialsBuilder.append(String.format(
                 "<o:UsernameToken u:Id='uuid-"
@@ -177,7 +177,7 @@ class WSTrustRequest {
                 + "<u:Created>%s</u:Created>" + // created
                 "<u:Expires>%s</u:Expires>" + // Expires
                 "</u:Timestamp>",
-                currentTimeString, expiryTimString));
+                currentTimeString, expiryTimeString));
         securityHeaderBuilder.append(messageCredentialsBuilder.toString());
         securityHeaderBuilder.append("</o:Security>");
 

--- a/src/main/java/com/microsoft/aad/adal4j/WsTrustVersion.java
+++ b/src/main/java/com/microsoft/aad/adal4j/WsTrustVersion.java
@@ -1,25 +1,45 @@
-/*******************************************************************************
+/**
+ * *****************************************************************************
  * Copyright © Microsoft Open Technologies, Inc.
- * 
+ *
  * All Rights Reserved
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
- * OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
- * ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
- * PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
- * 
- * See the Apache License, Version 2.0 for the specific language
- * governing permissions and limitations under the License.
- ******************************************************************************/
-
+ *
+ * THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+ * WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+ * MERCHANTABILITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache License, Version 2.0 for the specific language governing
+ * permissions and limitations under the License.
+ * ****************************************************************************
+ */
 package com.microsoft.aad.adal4j;
 
 enum WsTrustVersion {
-    WSTRUST13, WSTRUST2005, UNDEFINED
+
+    WSTRUST13("//s:Envelope/s:Body/wst:RequestSecurityTokenResponseCollection/wst:RequestSecurityTokenResponse/wst:TokenType",
+    "wst:RequestedSecurityToken"),
+    WSTRUST2005("//s:Envelope/s:Body/t:RequestSecurityTokenResponse/t:TokenType",
+    "t:RequestedSecurityToken"), UNDEFINED("", "");
+    private String responseTokenTypePath = "";
+    private String responseSecurityTokenPath = "";
+
+    private WsTrustVersion(String tokenType, String responseSecurityToken) {
+        this.responseTokenTypePath = tokenType;
+        this.responseSecurityTokenPath = responseSecurityToken;
+    }
+
+    public String getResponseTokenTypePath() {
+        return this.responseTokenTypePath;
+    }
+    
+    public String getResponseSecurityTokenPath(){
+        return this.responseSecurityTokenPath;
+    }
 }

--- a/src/test/java/com/microsoft/aad/adal4j/MexParserTest.java
+++ b/src/test/java/com/microsoft/aad/adal4j/MexParserTest.java
@@ -48,5 +48,25 @@ public class MexParserTest {
         Assert.assertEquals(endpoint.getUrl(),
                 "https://msft.sts.microsoft.com/adfs/services/trust/13/usernamemixed");
     }
+    
+    @Test
+    public void testMexParsingWs2005() throws Exception {
+
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader br = new BufferedReader(new FileReader(
+                (this.getClass().getResource(
+                        TestConfiguration.AAD_MEX_2005_RESPONSE_FILE).getFile())))) {
+            String line = br.readLine();
+
+            while (line != null) {
+                sb.append(line);
+                sb.append(System.lineSeparator());
+                line = br.readLine();
+            }
+        }
+        BindingPolicy endpoint = MexParser.getWsTrustEndpointFromMexResponse(sb
+                .toString());
+        Assert.assertEquals(endpoint.getUrl(),"https://msft.sts.microsoft.com/adfs/services/trust/2005/usernamemixed");
+    }
 
 }

--- a/src/test/java/com/microsoft/aad/adal4j/MexParserTest.java
+++ b/src/test/java/com/microsoft/aad/adal4j/MexParserTest.java
@@ -54,8 +54,8 @@ public class MexParserTest {
 
         StringBuilder sb = new StringBuilder();
         try (BufferedReader br = new BufferedReader(new FileReader(
-                (this.getClass().getResource(
-                        TestConfiguration.AAD_MEX_2005_RESPONSE_FILE).getFile())))) {
+                this.getClass().getResource(
+                TestConfiguration.AAD_MEX_2005_RESPONSE_FILE).getFile()))) {
             String line = br.readLine();
 
             while (line != null) {

--- a/src/test/java/com/microsoft/aad/adal4j/TestConfiguration.java
+++ b/src/test/java/com/microsoft/aad/adal4j/TestConfiguration.java
@@ -30,6 +30,7 @@ public final class TestConfiguration {
     public final static String AAD_RESOURCE_ID = "b7a671d8-a408-42ff-86e0-aaf447fd17c4";
     public final static String AAD_CERTIFICATE_PATH = "/test-certificate.pfx";
     public final static String AAD_MEX_RESPONSE_FILE = "/mex-response.xml";
+    public final static String AAD_MEX_2005_RESPONSE_FILE = "/mex-2005-response.xml";
     public final static String AAD_TOKEN_ERROR_FILE = "/token-error.xml";
     public final static String AAD_TOKEN_SUCCESS_FILE = "/token.xml";
     public final static String AAD_CERTIFICATE_PASSWORD = "password";

--- a/src/test/java/com/microsoft/aad/adal4j/WSTrustResponseTest.java
+++ b/src/test/java/com/microsoft/aad/adal4j/WSTrustResponseTest.java
@@ -42,7 +42,7 @@ public class WSTrustResponseTest {
                 line = br.readLine();
             }
         }
-        WSTrustResponse response = WSTrustResponse.parse(sb.toString());
+        WSTrustResponse response = WSTrustResponse.parse(sb.toString(), WsTrustVersion.WSTRUST13);
         Assert.assertNotNull(response);
     }
 
@@ -60,7 +60,7 @@ public class WSTrustResponseTest {
                 line = br.readLine();
             }
         }
-        WSTrustResponse response = WSTrustResponse.parse(sb.toString());
+        WSTrustResponse response = WSTrustResponse.parse(sb.toString(), WsTrustVersion.WSTRUST13);
         Assert.assertNotNull(response);
     }
 }

--- a/src/test/resources/mex-2005-response.xml
+++ b/src/test/resources/mex-2005-response.xml
@@ -1,0 +1,771 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SecurityTokenService"
+	targetNamespace="http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice"
+	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:t="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+	xmlns:tns="http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice"
+	xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract"
+	xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata"
+	xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsa10="http://www.w3.org/2005/08/addressing"
+	xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+	xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex"
+	xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy"
+	xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+	xmlns:trust="http://docs.oasis-open.org/ws-sx/ws-trust/200512"
+	xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+	<wsp:Policy wsu:Id="CustomBinding_IWSTrustFeb2005Async_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<http:NegotiateAuthentication
+					xmlns:http="http://schemas.microsoft.com/ws/06/2004/policy/http" />
+				<sp:TransportBinding
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="false" />
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256 />
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict />
+							</wsp:Policy>
+						</sp:Layout>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<wsaw:UsingAddressing />
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="CertificateWSTrustBinding_IWSTrustFeb2005Async_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="false" />
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256 />
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict />
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp />
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:EndorsingSupportingTokens
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:X509Token
+							sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+							<wsp:Policy>
+								<sp:RequireThumbprintReference />
+								<sp:WssX509V3Token10 />
+							</wsp:Policy>
+						</sp:X509Token>
+						<mssp:RsaToken
+							sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never"
+							wsp:Optional="true"
+							xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" />
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:MustSupportRefThumbprint />
+					</wsp:Policy>
+				</sp:Wss11>
+				<sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens />
+						<sp:RequireClientEntropy />
+						<sp:RequireServerEntropy />
+					</wsp:Policy>
+				</sp:Trust10>
+				<wsaw:UsingAddressing />
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="CertificateWSTrustBinding_IWSTrustFeb2005Async1_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="true" />
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256 />
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict />
+							</wsp:Policy>
+						</sp:Layout>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<wsaw:UsingAddressing />
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="UserNameWSTrustBinding_IWSTrustFeb2005Async_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="false" />
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256 />
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict />
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp />
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:SignedSupportingTokens
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:UsernameToken
+							sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+							<wsp:Policy>
+								<sp:WssUsernameToken10 />
+							</wsp:Policy>
+						</sp:UsernameToken>
+					</wsp:Policy>
+				</sp:SignedSupportingTokens>
+				<sp:EndorsingSupportingTokens
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<mssp:RsaToken
+							sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never"
+							wsp:Optional="true"
+							xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" />
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy />
+				</sp:Wss11>
+				<sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens />
+						<sp:RequireClientEntropy />
+						<sp:RequireServerEntropy />
+					</wsp:Policy>
+				</sp:Trust10>
+				<wsaw:UsingAddressing />
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="CustomBinding_IWSTrustFeb2005Async1_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="false" />
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic128 />
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict />
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp />
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:EndorsingSupportingTokens
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:KerberosToken
+							sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Once">
+							<wsp:Policy>
+								<sp:WssGssKerberosV5ApReqToken11 />
+							</wsp:Policy>
+						</sp:KerberosToken>
+						<mssp:RsaToken
+							sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never"
+							wsp:Optional="true"
+							xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" />
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy />
+				</sp:Wss11>
+				<sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens />
+						<sp:RequireClientEntropy />
+						<sp:RequireServerEntropy />
+					</wsp:Policy>
+				</sp:Trust10>
+				<wsaw:UsingAddressing />
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="false" />
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256 />
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict />
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp />
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:EndorsingSupportingTokens
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:IssuedToken
+							sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+							<sp:RequestSecurityTokenTemplate>
+								<t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/PublicKey
+								</t:KeyType>
+								<t:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p
+								</t:EncryptWith>
+								<t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1
+								</t:SignatureAlgorithm>
+								<t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#
+								</t:CanonicalizationAlgorithm>
+								<t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc
+								</t:EncryptionAlgorithm>
+							</sp:RequestSecurityTokenTemplate>
+							<wsp:Policy>
+								<sp:RequireInternalReference />
+							</wsp:Policy>
+						</sp:IssuedToken>
+						<mssp:RsaToken
+							sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never"
+							wsp:Optional="true"
+							xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" />
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy />
+				</sp:Wss11>
+				<sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens />
+						<sp:RequireClientEntropy />
+						<sp:RequireServerEntropy />
+					</wsp:Policy>
+				</sp:Trust10>
+				<wsaw:UsingAddressing />
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="false" />
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256 />
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict />
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp />
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:EndorsingSupportingTokens
+					xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:IssuedToken
+							sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+							<sp:RequestSecurityTokenTemplate>
+								<t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/SymmetricKey
+								</t:KeyType>
+								<t:KeySize>256</t:KeySize>
+								<t:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc
+								</t:EncryptWith>
+								<t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1
+								</t:SignatureAlgorithm>
+								<t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#
+								</t:CanonicalizationAlgorithm>
+								<t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc
+								</t:EncryptionAlgorithm>
+							</sp:RequestSecurityTokenTemplate>
+							<wsp:Policy>
+								<sp:RequireInternalReference />
+							</wsp:Policy>
+						</sp:IssuedToken>
+						<mssp:RsaToken
+							sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never"
+							wsp:Optional="true"
+							xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" />
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy />
+				</sp:Wss11>
+				<sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens />
+						<sp:RequireClientEntropy />
+						<sp:RequireServerEntropy />
+					</wsp:Policy>
+				</sp:Trust10>
+				<wsaw:UsingAddressing />
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	
+	<wsdl:types>
+		<xsd:schema
+			targetNamespace="http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice/Imports">
+			<xsd:import
+				schemaLocation="https://msft.sts.microsoft.com/adfs/services/trust/mex?xsd=xsd0"
+				namespace="http://schemas.microsoft.com/Message" />
+			<xsd:import
+				schemaLocation="https://msft.sts.microsoft.com/adfs/services/trust/mex?xsd=xsd1"
+				namespace="http://schemas.xmlsoap.org/ws/2005/02/trust" />
+			<xsd:import
+				schemaLocation="https://msft.sts.microsoft.com/adfs/services/trust/mex?xsd=xsd2"
+				namespace="http://docs.oasis-open.org/ws-sx/ws-trust/200512" />
+		</xsd:schema>
+	</wsdl:types>
+	<wsdl:message
+		name="IWSTrustFeb2005Async_TrustFeb2005IssueAsync_InputMessage">
+		<wsdl:part name="request" element="t:RequestSecurityToken" />
+	</wsdl:message>
+	<wsdl:message
+		name="IWSTrustFeb2005Async_TrustFeb2005IssueAsync_OutputMessage">
+		<wsdl:part name="TrustFeb2005IssueAsyncResult" element="t:RequestSecurityTokenResponse" />
+	</wsdl:message>
+	<wsdl:message name="IWSTrust13Async_Trust13IssueAsync_InputMessage">
+		<wsdl:part name="request" element="trust:RequestSecurityToken" />
+	</wsdl:message>
+	<wsdl:message name="IWSTrust13Async_Trust13IssueAsync_OutputMessage">
+		<wsdl:part name="Trust13IssueAsyncResult"
+			element="trust:RequestSecurityTokenResponseCollection" />
+	</wsdl:message>
+	<wsdl:portType name="IWSTrustFeb2005Async">
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<wsdl:input wsaw:Action="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue"
+				message="tns:IWSTrustFeb2005Async_TrustFeb2005IssueAsync_InputMessage" />
+			<wsdl:output wsaw:Action="http://schemas.xmlsoap.org/ws/2005/02/trust/RSTR/Issue"
+				message="tns:IWSTrustFeb2005Async_TrustFeb2005IssueAsync_OutputMessage" />
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:portType name="IWSTrust13Async">
+		<wsdl:operation name="Trust13IssueAsync">
+			<wsdl:input
+				wsaw:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"
+				message="tns:IWSTrust13Async_Trust13IssueAsync_InputMessage" />
+			<wsdl:output
+				wsaw:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTRC/IssueFinal"
+				message="tns:IWSTrust13Async_Trust13IssueAsync_OutputMessage" />
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="CustomBinding_IWSTrustFeb2005Async"
+		type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference URI="#CustomBinding_IWSTrustFeb2005Async_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation
+				soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="CertificateWSTrustBinding_IWSTrustFeb2005Async"
+		type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference
+			URI="#CertificateWSTrustBinding_IWSTrustFeb2005Async_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation
+				soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="CertificateWSTrustBinding_IWSTrustFeb2005Async1"
+		type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference
+			URI="#CertificateWSTrustBinding_IWSTrustFeb2005Async1_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation
+				soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="UserNameWSTrustBinding_IWSTrustFeb2005Async"
+		type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference
+			URI="#UserNameWSTrustBinding_IWSTrustFeb2005Async_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation
+				soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="CustomBinding_IWSTrustFeb2005Async1"
+		type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference URI="#CustomBinding_IWSTrustFeb2005Async1_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation
+				soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async"
+		type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference
+			URI="#IssuedTokenWSTrustBinding_IWSTrustFeb2005Async_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation
+				soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1"
+		type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference
+			URI="#IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation
+				soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="CustomBinding_IWSTrust13Async" type="tns:IWSTrust13Async">
+		<wsp:PolicyReference URI="#CustomBinding_IWSTrust13Async_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="Trust13IssueAsync">
+			<soap12:operation
+				soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="CertificateWSTrustBinding_IWSTrust13Async"
+		type="tns:IWSTrust13Async">
+		<wsp:PolicyReference
+			URI="#CertificateWSTrustBinding_IWSTrust13Async_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="Trust13IssueAsync">
+			<soap12:operation
+				soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="UserNameWSTrustBinding_IWSTrust13Async"
+		type="tns:IWSTrust13Async">
+		<wsp:PolicyReference URI="#UserNameWSTrustBinding_IWSTrust13Async_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="Trust13IssueAsync">
+			<soap12:operation
+				soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrust13Async"
+		type="tns:IWSTrust13Async">
+		<wsp:PolicyReference
+			URI="#IssuedTokenWSTrustBinding_IWSTrust13Async_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="Trust13IssueAsync">
+			<soap12:operation
+				soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrust13Async1"
+		type="tns:IWSTrust13Async">
+		<wsp:PolicyReference
+			URI="#IssuedTokenWSTrustBinding_IWSTrust13Async1_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="Trust13IssueAsync">
+			<soap12:operation
+				soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="CustomBinding_IWSTrust13Async1" type="tns:IWSTrust13Async">
+		<wsp:PolicyReference URI="#CustomBinding_IWSTrust13Async1_policy" />
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="Trust13IssueAsync">
+			<soap12:operation
+				soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"
+				style="document" />
+			<wsdl:input>
+				<soap12:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="SecurityTokenService">
+		<wsdl:port name="CustomBinding_IWSTrustFeb2005Async"
+			binding="tns:CustomBinding_IWSTrustFeb2005Async">
+			<soap12:address
+				location="https://msft.sts.microsoft.com/adfs/services/trust/2005/windowstransport" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/windowstransport
+				</wsa10:Address>
+				<Identity xmlns="http://schemas.xmlsoap.org/ws/2006/02/addressingidentity">
+					<Spn>HTTP/adfsintf0-30.gtm.corp.microsoft.com</Spn>
+				</Identity>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="CertificateWSTrustBinding_IWSTrustFeb2005Async"
+			binding="tns:CertificateWSTrustBinding_IWSTrustFeb2005Async">
+			<soap12:address
+				location="https://msft.sts.microsoft.com/adfs/services/trust/2005/certificatemixed" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/certificatemixed
+				</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="CertificateWSTrustBinding_IWSTrustFeb2005Async1"
+			binding="tns:CertificateWSTrustBinding_IWSTrustFeb2005Async1">
+			<soap12:address
+				location="https://msft.sts.microsoft.com:49443/adfs/services/trust/2005/certificatetransport" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com:49443/adfs/services/trust/2005/certificatetransport
+				</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="UserNameWSTrustBinding_IWSTrustFeb2005Async"
+			binding="tns:UserNameWSTrustBinding_IWSTrustFeb2005Async">
+			<soap12:address
+				location="https://msft.sts.microsoft.com/adfs/services/trust/2005/usernamemixed" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/usernamemixed
+				</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="CustomBinding_IWSTrustFeb2005Async1"
+			binding="tns:CustomBinding_IWSTrustFeb2005Async1">
+			<soap12:address
+				location="https://msft.sts.microsoft.com/adfs/services/trust/2005/kerberosmixed" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/kerberosmixed
+				</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async"
+			binding="tns:IssuedTokenWSTrustBinding_IWSTrustFeb2005Async">
+			<soap12:address
+				location="https://msft.sts.microsoft.com/adfs/services/trust/2005/issuedtokenmixedasymmetricbasic256" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/issuedtokenmixedasymmetricbasic256
+				</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1"
+			binding="tns:IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1">
+			<soap12:address
+				location="https://msft.sts.microsoft.com/adfs/services/trust/2005/issuedtokenmixedsymmetricbasic256" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/issuedtokenmixedsymmetricbasic256
+				</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="CustomBinding_IWSTrust13Async" binding="tns:CustomBinding_IWSTrust13Async">
+			<soap12:address
+				location="https://msft.sts.microsoft.com/adfs/services/trust/13/kerberosmixed" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/kerberosmixed
+				</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="CertificateWSTrustBinding_IWSTrust13Async"
+			binding="tns:CertificateWSTrustBinding_IWSTrust13Async">
+			<soap12:address
+				location="https://msft.sts.microsoft.com/adfs/services/trust/13/certificatemixed" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/certificatemixed
+				</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="UserNameWSTrustBinding_IWSTrust13Async"
+			binding="tns:UserNameWSTrustBinding_IWSTrust13Async">
+			<soap12:address
+				location="https://msft.sts.microsoft.com/adfs/services/trust/13/usernamemixed" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/usernamemixed
+				</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="IssuedTokenWSTrustBinding_IWSTrust13Async"
+			binding="tns:IssuedTokenWSTrustBinding_IWSTrust13Async">
+			<soap12:address
+				location="https://msft.sts.microsoft.com/adfs/services/trust/13/issuedtokenmixedasymmetricbasic256" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/issuedtokenmixedasymmetricbasic256
+				</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="IssuedTokenWSTrustBinding_IWSTrust13Async1"
+			binding="tns:IssuedTokenWSTrustBinding_IWSTrust13Async1">
+			<soap12:address
+				location="https://msft.sts.microsoft.com/adfs/services/trust/13/issuedtokenmixedsymmetricbasic256" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/issuedtokenmixedsymmetricbasic256
+				</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="CustomBinding_IWSTrust13Async1" binding="tns:CustomBinding_IWSTrust13Async1">
+			<soap12:address
+				location="https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport" />
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport
+				</wsa10:Address>
+				<Identity xmlns="http://schemas.xmlsoap.org/ws/2006/02/addressingidentity">
+					<Spn>HTTP/adfsintf0-30.gtm.corp.microsoft.com</Spn>
+				</Identity>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Test E2E for ws2005 with correct request soap msg.
Namespace for sp needs to be modified to pick up the Ws2005 endpoint.
Soap request is verified for actual Wstrust2005 endpoint.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/45%23discussion_r35899554%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/45%23discussion_r35899822%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/45%23issuecomment-126449275%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/45%23issuecomment-126457190%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/45%23issuecomment-126522005%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/45%23issuecomment-126449275%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20disabled%201.3%20on%20my%20ADFS%20and%20wrote%20a%20small%20sample%20app%20to%20test%20this%20flow.%20I%20get%20this%20exception%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5CnException%20in%20thread%20%5C%22main%5C%22%20java.util.concurrent.ExecutionException%3A%20java.lang.Exception%3A%20Unable%20to%20find%20any%20tokens%20in%20RSTR%5Cr%5Cn%5Ctat%20java.util.concurrent.FutureTask.report%28FutureTask.java%3A122%29%5Cr%5Cn%5Ctat%20java.util.concurrent.FutureTask.get%28FutureTask.java%3A188%29%5Cr%5Cn%5Ctat%20com.microsoft.aad.adal4j.AdamMain.main%28AdamMain.java%3A24%29%5Cr%5CnCaused%20by%3A%20java.lang.Exception%3A%20Unable%20to%20find%20any%20tokens%20in%20RSTR%5Cr%5Cn%5Ctat%20com.microsoft.aad.adal4j.WSTrustResponse.parseToken%28WSTrustResponse.java%3A160%29%5Cr%5Cn%5Ctat%20com.microsoft.aad.adal4j.WSTrustResponse.parse%28WSTrustResponse.java%3A107%29%5Cr%5Cn%5Ctat%20com.microsoft.aad.adal4j.WSTrustRequest.execute%28WSTrustRequest.java%3A64%29%5Cr%5Cn%5Ctat%20com.microsoft.aad.adal4j.AuthenticationContext.processPasswordGrant%28AuthenticationContext.java%3A790%29%5Cr%5Cn%5Ctat%20com.microsoft.aad.adal4j.AuthenticationContext.access%24000%28AuthenticationContext.java%3A63%29%5Cr%5Cn%5Ctat%20com.microsoft.aad.adal4j.AuthenticationContext%241.call%28AuthenticationContext.java%3A129%29%5Cr%5Cn%5Ctat%20com.microsoft.aad.adal4j.AuthenticationContext%241.call%28AuthenticationContext.java%3A119%29%5Cr%5Cn%5Ctat%20java.util.concurrent.FutureTask.run%28FutureTask.java%3A262%29%5Cr%5Cn%5Ctat%20java.util.concurrent.ThreadPoolExecutor.runWorker%28ThreadPoolExecutor.java%3A1145%29%5Cr%5Cn%5Ctat%20java.util.concurrent.ThreadPoolExecutor%24Worker.run%28ThreadPoolExecutor.java%3A615%29%5Cr%5Cn%5Ctat%20java.lang.Thread.run%28Thread.java%3A745%29%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnI%20will%20attempt%20to%20investigate%20further.%22%2C%20%22created_at%22%3A%20%222015-07-30T19%3A33%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7756476%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aj-michael%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20so%20the%20MexParser%20and%20WSTrustRequest%20look%20good%2C%20and%20I%27ve%20verified%20that%20they%20both%20work.%20However%2C%20parsing%20the%20WSTrustResponse%20does%20not%20seem%20to%20work.%20Two%20problems%20I%27ve%20noticed%20so%20far%3A%5Cr%5Cn1.%20We%27re%20still%20using%20the%20namespaces%20from%20NamespacesContextImpl%20which%20are%20using%201.3.%20%28Specifically%20%60wst%60%29.%5Cr%5Cn2.%20RequestSecurityTokenResponseCollection%20is%20not%20in%20any%20of%20the%20responses%20I%27m%20seeing.%20Speculation%3A%20Maybe%20this%20is%20ommitted%20if%20only%20one%20token%20response%20is%20included%3F%22%2C%20%22created_at%22%3A%20%222015-07-30T19%3A54%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7756476%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aj-michael%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nice%21%20It%20works%20on%20my%20machine%20on%20my%20adfs%20Instance.%20I%20also%20checked%20that%20it%20still%20works%20for%201.3.%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-07-30T23%3A39%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7756476%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aj-michael%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206e89dd1457c890d6bd6e0f2d1d263c814db2b1da%20src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java%2098%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/45%23discussion_r35899554%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Super%20nitpick%3A%20but%20could%20this%20be%20%60expiryTimeString%60%3F%22%2C%20%22created_at%22%3A%20%222015-07-30T17%3A57%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7756476%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aj-michael%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java%3AL161-186%22%7D%2C%20%22Pull%206e89dd1457c890d6bd6e0f2d1d263c814db2b1da%20src/test/java/com/microsoft/aad/adal4j/MexParserTest.java%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/45%23discussion_r35899822%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Super%20nitpick%3A%20Unnecessary%20parentheses.%22%2C%20%22created_at%22%3A%20%222015-07-30T17%3A59%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7756476%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aj-michael%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/java/com/microsoft/aad/adal4j/MexParserTest.java%3AL48-73%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 6e89dd1457c890d6bd6e0f2d1d263c814db2b1da src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java 98'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/45#discussion_r35899554'>File: src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java:L161-186</a></b>
- <a href='https://github.com/aj-michael'><img border=0 src='https://avatars.githubusercontent.com/u/7756476?v=3' height=16 width=16'></a> Super nitpick: but could this be `expiryTimeString`?
- [ ] <a href='#crh-comment-Pull 6e89dd1457c890d6bd6e0f2d1d263c814db2b1da src/test/java/com/microsoft/aad/adal4j/MexParserTest.java 10'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/45#discussion_r35899822'>File: src/test/java/com/microsoft/aad/adal4j/MexParserTest.java:L48-73</a></b>
- <a href='https://github.com/aj-michael'><img border=0 src='https://avatars.githubusercontent.com/u/7756476?v=3' height=16 width=16'></a> Super nitpick: Unnecessary parentheses.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/45#issuecomment-126449275'>General Comment</a></b>
- <a href='https://github.com/aj-michael'><img border=0 src='https://avatars.githubusercontent.com/u/7756476?v=3' height=16 width=16'></a> I disabled 1.3 on my ADFS and wrote a small sample app to test this flow. I get this exception:
```
Exception in thread "main" java.util.concurrent.ExecutionException: java.lang.Exception: Unable to find any tokens in RSTR
at java.util.concurrent.FutureTask.report(FutureTask.java:122)
at java.util.concurrent.FutureTask.get(FutureTask.java:188)
at com.microsoft.aad.adal4j.AdamMain.main(AdamMain.java:24)
Caused by: java.lang.Exception: Unable to find any tokens in RSTR
at com.microsoft.aad.adal4j.WSTrustResponse.parseToken(WSTrustResponse.java:160)
at com.microsoft.aad.adal4j.WSTrustResponse.parse(WSTrustResponse.java:107)
at com.microsoft.aad.adal4j.WSTrustRequest.execute(WSTrustRequest.java:64)
at com.microsoft.aad.adal4j.AuthenticationContext.processPasswordGrant(AuthenticationContext.java:790)
at com.microsoft.aad.adal4j.AuthenticationContext.access$000(AuthenticationContext.java:63)
at com.microsoft.aad.adal4j.AuthenticationContext$1.call(AuthenticationContext.java:129)
at com.microsoft.aad.adal4j.AuthenticationContext$1.call(AuthenticationContext.java:119)
at java.util.concurrent.FutureTask.run(FutureTask.java:262)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
at java.lang.Thread.run(Thread.java:745)
```
I will attempt to investigate further.
- <a href='https://github.com/aj-michael'><img border=0 src='https://avatars.githubusercontent.com/u/7756476?v=3' height=16 width=16'></a> Ok, so the MexParser and WSTrustRequest look good, and I've verified that they both work. However, parsing the WSTrustResponse does not seem to work. Two problems I've noticed so far:
1. We're still using the namespaces from NamespacesContextImpl which are using 1.3. (Specifically `wst`).
2. RequestSecurityTokenResponseCollection is not in any of the responses I'm seeing. Speculation: Maybe this is ommitted if only one token response is included?
- <a href='https://github.com/aj-michael'><img border=0 src='https://avatars.githubusercontent.com/u/7756476?v=3' height=16 width=16'></a> Nice! It works on my machine on my adfs Instance. I also checked that it still works for 1.3.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-java/pull/45?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-java/pull/45?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/45'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>