### PR TITLE
Fix for issue 55 (Proxy support)

### DIFF
--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationAuthority.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationAuthority.java
@@ -19,6 +19,7 @@
  ******************************************************************************/
 package com.microsoft.aad.adal4j;
 
+import java.net.Proxy;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Map;
@@ -62,12 +63,27 @@ class AuthenticationAuthority {
     private final URL authorityUrl;
     private final boolean validateAuthority;
 
+    private final Proxy proxy;
+
     AuthenticationAuthority(final URL authorityUrl,
             final boolean validateAuthority) {
 
         this.authorityUrl = authorityUrl;
         this.authorityType = detectAuthorityType();
         this.validateAuthority = validateAuthority;
+        proxy = Proxy.NO_PROXY;
+        validateAuthorityUrl();
+        setupAuthorityProperties();
+    }
+
+    AuthenticationAuthority(final URL authorityUrl,
+                            final boolean validateAuthority,
+                            final Proxy proxy) {
+
+        this.authorityUrl = authorityUrl;
+        this.authorityType = detectAuthorityType();
+        this.validateAuthority = validateAuthority;
+        this.proxy = proxy;
         validateAuthorityUrl();
         setupAuthorityProperties();
     }
@@ -135,8 +151,7 @@ class AuthenticationAuthority {
 
     boolean doDynamicInstanceDiscovery(final Map<String, String> headers)
             throws Exception {
-        final String json = HttpHelper.executeHttpGet(log,
-                instanceDiscoveryEndpoint, headers);
+        final String json = HttpHelper.executeHttpGet(log, instanceDiscoveryEndpoint, headers, proxy);
         final InstanceDiscoveryResponse discoveryResponse = JsonHelper
                 .convertJsonToObject(json, InstanceDiscoveryResponse.class);
         return !StringHelper.isBlank(discoveryResponse

--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationAuthority.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationAuthority.java
@@ -63,7 +63,7 @@ class AuthenticationAuthority {
     private final URL authorityUrl;
     private final boolean validateAuthority;
 
-    private final Proxy proxy;
+    private Proxy proxy;
 
     AuthenticationAuthority(final URL authorityUrl,
             final boolean validateAuthority) {
@@ -71,21 +71,16 @@ class AuthenticationAuthority {
         this.authorityUrl = authorityUrl;
         this.authorityType = detectAuthorityType();
         this.validateAuthority = validateAuthority;
-        proxy = Proxy.NO_PROXY;
         validateAuthorityUrl();
         setupAuthorityProperties();
     }
 
-    AuthenticationAuthority(final URL authorityUrl,
-                            final boolean validateAuthority,
-                            final Proxy proxy) {
+    public Proxy getProxy() {
+        return proxy;
+    }
 
-        this.authorityUrl = authorityUrl;
-        this.authorityType = detectAuthorityType();
-        this.validateAuthority = validateAuthority;
+    public void setProxy(Proxy proxy) {
         this.proxy = proxy;
-        validateAuthorityUrl();
-        setupAuthorityProperties();
     }
 
     String getHost() {

--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -71,7 +71,7 @@ public class AuthenticationContext {
     private String authority;
     private final ExecutorService service;
     private final boolean validateAuthority;
-    private final Proxy proxy;
+    private Proxy proxy;
 
     /**
      * Constructor to create the context with the address of the authority.
@@ -101,46 +101,18 @@ public class AuthenticationContext {
         this.service = service;
         this.validateAuthority = validateAuthority;
         this.authority = this.canonicalizeUri(authority);
-        this.proxy = Proxy.NO_PROXY;
 
         authenticationAuthority = new AuthenticationAuthority(new URL(
                 this.getAuthority()), this.shouldValidateAuthority());
     }
 
-    /**
-     * Constructor to create the context with the address of the authority.
-     *
-     * @param authority
-     *            URL of the authenticating authority
-     * @param validateAuthority
-     *            flag to enable/disable authority validation.
-     * @param service
-     *            ExecutorService to be used to execute the requests. Developer
-     *            is responsible for maintaining the lifetime of the
-     *            ExecutorService.
-     * @param proxy
-     *            which will be used for http requests
-     * @throws MalformedURLException
-     *             thrown if URL is invalid
-     */
-    public AuthenticationContext(final String authority,
-                                 final boolean validateAuthority, final ExecutorService service, final Proxy proxy)
-            throws MalformedURLException {
+    public Proxy getProxy() {
+        return proxy;
+    }
 
-        if (StringHelper.isBlank(authority)) {
-            throw new IllegalArgumentException("authority is null or empty");
-        }
-
-        if (service == null) {
-            throw new IllegalArgumentException("service is null");
-        }
-        this.service = service;
-        this.validateAuthority = validateAuthority;
-        this.authority = this.canonicalizeUri(authority);
+    public void setProxy(Proxy proxy) {
         this.proxy = proxy;
-
-        authenticationAuthority = new AuthenticationAuthority(new URL(
-                this.getAuthority()), this.shouldValidateAuthority(), proxy);;
+        authenticationAuthority.setProxy(proxy);
     }
 
     private String canonicalizeUri(String authority) {

--- a/src/main/java/com/microsoft/aad/adal4j/HttpHelper.java
+++ b/src/main/java/com/microsoft/aad/adal4j/HttpHelper.java
@@ -36,7 +36,7 @@ class HttpHelper {
 
     static String executeHttpGet(final Logger log, final String url)
             throws Exception {
-        return executeHttpGet(log, url, null, Proxy.NO_PROXY);
+        return executeHttpGet(log, url, null, null);
     }
 
     static String executeHttpGet(final Logger log, final String url, final Proxy proxy)
@@ -52,7 +52,10 @@ class HttpHelper {
 
     static String executeHttpGet(final Logger log, final String url,
                                  final Map<String, String> headers, final Proxy proxy) throws Exception {
-        final HttpURLConnection conn = HttpHelper.openConnection(url, proxy);
+        final HttpURLConnection conn =
+                    proxy == null ?
+                            HttpHelper.openConnection(url) :
+                            HttpHelper.openConnection(url, proxy);
         return executeGetRequest(log, headers, conn);
     }
 
@@ -71,7 +74,10 @@ class HttpHelper {
     static String executeHttpPost(final Logger log, final String url,
                                   String postData, final Map<String, String> headers, final Proxy proxy)
             throws Exception {
-        final HttpURLConnection conn = HttpHelper.openConnection(url, proxy);
+        final HttpURLConnection conn =
+                    proxy == null ?
+                            HttpHelper.openConnection(url) :
+                            HttpHelper.openConnection(url, proxy);
         return executePostRequest(log, postData, headers, conn);
     }
 

--- a/src/main/java/com/microsoft/aad/adal4j/HttpHelper.java
+++ b/src/main/java/com/microsoft/aad/adal4j/HttpHelper.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.Proxy;
 import java.net.URL;
 import java.util.Map;
 
@@ -35,19 +36,24 @@ class HttpHelper {
 
     static String executeHttpGet(final Logger log, final String url)
             throws Exception {
-        return executeHttpGet(log, url, null);
+        return executeHttpGet(log, url, null, null);
+    }
+
+    static String executeHttpGet(final Logger log, final String url, final Proxy proxy)
+            throws Exception {
+        return executeHttpGet(log, url, null, proxy);
     }
 
     static String executeHttpGet(final Logger log, final String url,
             final Map<String, String> headers) throws Exception {
         final HttpURLConnection conn = HttpHelper.openConnection(url);
-        configureAdditionalHeaders(conn, headers);
-        String response = readResponseFromConnection(conn);
-        if (headers != null) {
-            HttpHelper.verifyReturnedCorrelationId(log, conn, headers
-                    .get(ClientDataHttpHeaders.CORRELATION_ID_HEADER_NAME));
-        }
-        return response;
+        return executeGetRequest(log, headers, conn);
+    }
+
+    static String executeHttpGet(final Logger log, final String url,
+                                 final Map<String, String> headers, final Proxy proxy) throws Exception {
+        final HttpURLConnection conn = HttpHelper.openConnection(url, proxy);
+        return executeGetRequest(log, headers, conn);
     }
 
     static String executeHttpPost(final Logger log, final String url,
@@ -59,22 +65,14 @@ class HttpHelper {
             String postData, final Map<String, String> headers)
             throws Exception {
         final HttpURLConnection conn = HttpHelper.openConnection(url);
-        configureAdditionalHeaders(conn, headers);
-        conn.setRequestMethod("POST");
-        conn.setDoOutput(true);
-        DataOutputStream wr = null;
-        try {
-            wr = new DataOutputStream(conn.getOutputStream());
-            wr.writeBytes(postData);
-            wr.flush();
+        return executePostRequest(log, postData, headers, conn);
+    }
 
-            String response = readResponseFromConnection(conn);
-            HttpHelper.verifyReturnedCorrelationId(log, conn, headers
-                    .get(ClientDataHttpHeaders.CORRELATION_ID_HEADER_NAME));
-            return response;
-        } finally {
-            wr.close();
-        }
+    static String executeHttpPost(final Logger log, final String url,
+                                  String postData, final Map<String, String> headers, final Proxy proxy)
+            throws Exception {
+        final HttpURLConnection conn = HttpHelper.openConnection(url, proxy);
+        return executePostRequest(log, postData, headers, conn);
     }
 
     static String readResponseFromConnection(final HttpURLConnection conn)
@@ -100,9 +98,19 @@ class HttpHelper {
         return out.toString();
     }
 
+    static HttpURLConnection openConnection(final URL finalURL, final Proxy proxy)
+            throws IOException  {
+        return (HttpURLConnection) finalURL.openConnection(proxy);
+    }
+
     static HttpURLConnection openConnection(final URL finalURL)
             throws IOException {
         return (HttpURLConnection) finalURL.openConnection();
+    }
+
+    static HttpURLConnection openConnection(final String url, final Proxy proxy)
+            throws IOException {
+        return openConnection(new URL(url), proxy);
     }
 
     static HttpURLConnection openConnection(final String url)
@@ -138,4 +146,38 @@ class HttpHelper {
         }
     }
 
+    private static String executeGetRequest(Logger log, Map<String, String> headers, HttpURLConnection conn)
+            throws IOException {
+        configureAdditionalHeaders(conn, headers);
+        return getResponse(log, headers, conn);
+    }
+
+    private static String executePostRequest(Logger log, String postData, Map<String, String> headers,
+                                             HttpURLConnection conn) throws IOException {
+        configureAdditionalHeaders(conn, headers);
+        conn.setRequestMethod("POST");
+        conn.setDoOutput(true);
+        DataOutputStream wr = null;
+        try {
+            wr = new DataOutputStream(conn.getOutputStream());
+            wr.writeBytes(postData);
+            wr.flush();
+
+            return getResponse(log, headers, conn);
+        } finally {
+            if (wr != null) {
+                wr.close();
+            }
+        }
+    }
+
+    private static String getResponse(Logger log, Map<String, String> headers, HttpURLConnection conn)
+            throws IOException {
+        String response = readResponseFromConnection(conn);
+        if (headers != null) {
+            HttpHelper.verifyReturnedCorrelationId(log, conn, headers
+                    .get(ClientDataHttpHeaders.CORRELATION_ID_HEADER_NAME));
+        }
+        return response;
+    }
 }

--- a/src/main/java/com/microsoft/aad/adal4j/HttpHelper.java
+++ b/src/main/java/com/microsoft/aad/adal4j/HttpHelper.java
@@ -36,7 +36,7 @@ class HttpHelper {
 
     static String executeHttpGet(final Logger log, final String url)
             throws Exception {
-        return executeHttpGet(log, url, null, null);
+        return executeHttpGet(log, url, null, Proxy.NO_PROXY);
     }
 
     static String executeHttpGet(final Logger log, final String url, final Proxy proxy)

--- a/src/main/java/com/microsoft/aad/adal4j/MexParser.java
+++ b/src/main/java/com/microsoft/aad/adal4j/MexParser.java
@@ -20,6 +20,7 @@
 package com.microsoft.aad.adal4j;
 
 import java.io.ByteArrayInputStream;
+import java.net.Proxy;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -93,9 +94,9 @@ class MexParser {
         }
     }
 
-    static BindingPolicy getWsTrustEndpointFromMexEndpoint(String metadataEndpoint)
+    static BindingPolicy getWsTrustEndpointFromMexEndpoint(String metadataEndpoint, Proxy proxy)
             throws Exception {
-        String mexResponse = HttpHelper.executeHttpGet(log, metadataEndpoint);
+        String mexResponse = HttpHelper.executeHttpGet(log, metadataEndpoint, proxy);
         return getWsTrustEndpointFromMexResponse(mexResponse);
     }
 

--- a/src/main/java/com/microsoft/aad/adal4j/UserDiscoveryRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/UserDiscoveryRequest.java
@@ -19,6 +19,7 @@
  ******************************************************************************/
 package com.microsoft.aad.adal4j;
 
+import java.net.Proxy;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,8 +36,8 @@ class UserDiscoveryRequest {
         HEADERS.put("Accept", "application/json, text/javascript, */*");
         
     }
-    static UserDiscoveryResponse execute(String uri) throws Exception {
-       String response = HttpHelper.executeHttpGet(log, uri, HEADERS);
-       return JsonHelper.convertJsonToObject(response, UserDiscoveryResponse.class);
+    static UserDiscoveryResponse execute(final String uri, final Proxy proxy) throws Exception {
+        String response = HttpHelper.executeHttpGet(log, uri, HEADERS, proxy);
+        return JsonHelper.convertJsonToObject(response, UserDiscoveryResponse.class);
     }
 }

--- a/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
@@ -19,6 +19,7 @@
  ******************************************************************************/
 package com.microsoft.aad.adal4j;
 
+import java.net.Proxy;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -40,13 +41,13 @@ class WSTrustRequest {
     private final static int MAX_EXPECTED_MESSAGE_SIZE = 1024;
     private final static String DEFAULT_APPLIES_TO = "urn:federation:MicrosoftOnline";    
     
-    static WSTrustResponse execute(String url, String username, String password)
+    static WSTrustResponse execute(String url, String username, String password, Proxy proxy)
             throws Exception {
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Content-Type", "application/soap+xml; charset=utf-8");
 
 
-        BindingPolicy policy = MexParser.getWsTrustEndpointFromMexEndpoint(url);
+        BindingPolicy policy = MexParser.getWsTrustEndpointFromMexEndpoint(url, proxy);
         String soapAction = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"; // default value (WSTrust 1.3)
 
         // only change it if version is wsTrust2005, otherwise default to wsTrust13
@@ -57,7 +58,7 @@ class WSTrustRequest {
 
         headers.put("SOAPAction", soapAction);
         String body = buildMessage(policy.getUrl(), username, password, policy.getVersion()).toString();
-        String response = HttpHelper.executeHttpPost(log, policy.getUrl(), body, headers);
+        String response = HttpHelper.executeHttpPost(log, policy.getUrl(), body, headers, proxy);
         return WSTrustResponse.parse(response, policy.getVersion());
     }
 


### PR DESCRIPTION
Issue #55 
Added support for Proxy in AuthenticationContext and AuthenticationAuthority
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23issuecomment-144155515%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23issuecomment-144156561%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23discussion_r40909034%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23issuecomment-145526828%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23discussion_r41422719%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23discussion_r41422886%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23discussion_r41484439%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23discussion_r41694736%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23issuecomment-144155515%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40Vartlok__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20In%20order%20for%20us%20to%20evaluate%20and%20accept%20your%20PR%2C%20we%20ask%20that%20you%20sign%20a%20contribution%20license%20agreement.%20It%27s%20all%20electronic%20and%20will%20take%20just%20minutes.%20I%20promise%20there%27s%20no%20faxing.%20https%3A//cla.microsoft.com.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-29T18%3A55%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22__%40Vartlok__%2C%20Thanks%20for%20signing%20the%20contribution%20license%20agreement%20so%20quickly%21%20Actual%20humans%20will%20now%20validate%20the%20agreement%20and%20then%20evaluate%20the%20PR.%5Cr%5Cn%3Cbr%20/%3EThanks%2C%20MSBOT%3B%22%2C%20%22created_at%22%3A%20%222015-09-29T18%3A58%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22ping%22%2C%20%22created_at%22%3A%20%222015-10-05T13%3A26%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1530324%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Vartlok%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%209770259c059d81e8fa82c03df28e749827e2c4eb%20src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23discussion_r41694736%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Not%20sure%20about%20these%20changes.%20They%20look%20weird.%20I%20changed%20it%20in%20order%20to%20avoid%20constructor%20bloating.%22%2C%20%22created_at%22%3A%20%222015-10-10T08%3A11%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1530324%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Vartlok%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java%3AL106-121%22%7D%2C%20%22Pull%20a6ef8725b9129c2ce10ec0b31cd9206dae1ae0c8%20src/main/java/com/microsoft/aad/adal4j/HttpHelper.java%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23discussion_r40909034%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Consider%20passing%20Proxy.NO_PROXY%20instead%20of%20null.%22%2C%20%22created_at%22%3A%20%222015-10-01T12%3A51%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/com/microsoft/aad/adal4j/HttpHelper.java%3AL36-60%22%7D%2C%20%22Pull%20c8531a3de497ed7f9031244acb8ee655d8c15ae5%20src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23discussion_r41484439%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22prefer%20proxy%3Dnull.%20see%20reasoning%20above.%22%2C%20%22created_at%22%3A%20%222015-10-08T07%3A46%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java%3AL101-149%22%7D%2C%20%22Pull%20c8531a3de497ed7f9031244acb8ee655d8c15ae5%20src/main/java/com/microsoft/aad/adal4j/AuthenticationAuthority.java%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23discussion_r41422719%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22lets%20use%20proxy%20%3D%20null%22%2C%20%22created_at%22%3A%20%222015-10-07T17%3A53%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/com/microsoft/aad/adal4j/AuthenticationAuthority.java%3AL63-90%22%7D%2C%20%22Pull%20c8531a3de497ed7f9031244acb8ee655d8c15ae5%20src/main/java/com/microsoft/aad/adal4j/AuthenticationAuthority.java%2025%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-java/pull/58%23discussion_r41422886%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20expose%20proxy%20as%20a%20setter%20property%20of%20the%20instance%20instead%20of%20adding%20constructor.%20We%20want%20to%20avoid%20constructor%20bloating%20over%20a%20period%20of%20time.%22%2C%20%22created_at%22%3A%20%222015-10-07T17%3A54%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/com/microsoft/aad/adal4j/AuthenticationAuthority.java%3AL63-90%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/58#issuecomment-144155515'>General Comment</a></b>
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> Hi __@Vartlok__, I'm your friendly neighborhood Microsoft Pull Request Bot (You can call me MSBOT). Thanks for your contribution!
<span>
In order for us to evaluate and accept your PR, we ask that you sign a contribution license agreement. It's all electronic and will take just minutes. I promise there's no faxing. https://cla.microsoft.com.
</span>
TTYL, MSBOT;
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> __@Vartlok__, Thanks for signing the contribution license agreement so quickly! Actual humans will now validate the agreement and then evaluate the PR.
<br />Thanks, MSBOT;
- <a href='https://github.com/Vartlok'><img border=0 src='https://avatars.githubusercontent.com/u/1530324?v=3' height=16 width=16'></a> ping
- [x] <a href='#crh-comment-Pull a6ef8725b9129c2ce10ec0b31cd9206dae1ae0c8 src/main/java/com/microsoft/aad/adal4j/HttpHelper.java 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/58#discussion_r40909034'>File: src/main/java/com/microsoft/aad/adal4j/HttpHelper.java:L36-60</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> Consider passing Proxy.NO_PROXY instead of null.
- [ ] <a href='#crh-comment-Pull c8531a3de497ed7f9031244acb8ee655d8c15ae5 src/main/java/com/microsoft/aad/adal4j/AuthenticationAuthority.java 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/58#discussion_r41422719'>File: src/main/java/com/microsoft/aad/adal4j/AuthenticationAuthority.java:L63-90</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> lets use proxy = null
- [ ] <a href='#crh-comment-Pull c8531a3de497ed7f9031244acb8ee655d8c15ae5 src/main/java/com/microsoft/aad/adal4j/AuthenticationAuthority.java 25'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/58#discussion_r41422886'>File: src/main/java/com/microsoft/aad/adal4j/AuthenticationAuthority.java:L63-90</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> Please expose proxy as a setter property of the instance instead of adding constructor. We want to avoid constructor bloating over a period of time.
- [ ] <a href='#crh-comment-Pull c8531a3de497ed7f9031244acb8ee655d8c15ae5 src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/58#discussion_r41484439'>File: src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java:L101-149</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> prefer proxy=null. see reasoning above.
- [ ] <a href='#crh-comment-Pull 9770259c059d81e8fa82c03df28e749827e2c4eb src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java 26'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/58#discussion_r41694736'>File: src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java:L106-121</a></b>
- <a href='https://github.com/Vartlok'><img border=0 src='https://avatars.githubusercontent.com/u/1530324?v=3' height=16 width=16'></a> Not sure about these changes. They look weird. I changed it in order to avoid constructor bloating.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-java/pull/58?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-java/pull/58?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/58'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>