### PR TITLE
Draft: Add interactive auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
 			<artifactId>commons-codec</artifactId>
 			<version>1.10</version>
 		</dependency>
+		<dependency>
+			<groupId>com.microsoft.alm</groupId>
+			<artifactId>oauth2-useragent</artifactId>
+			<version>0.5.9</version>
+		</dependency>
 
 		<!-- test dependencies -->
 		<dependency>

--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -254,6 +254,16 @@ public class AuthenticationContext {
                 callback);
     }
 
+    public Future<AuthenticationResult> acquireToken(final String resource, final String clientId, final URI redirectUri, final PromptBehavior promptBehavior, final UserIdentifier userId, final String extraQueryParameters, final AuthenticationCallback callback) {
+        // TODO: construct an authorization endpoint URI from the parameters
+
+        // TODO: obtain an instance of UserAgentImpl (from the constructor, from parameter or create here)
+        // TODO: create an instance of InteractiveAuthorizationGrant
+        // TODO: call private acquireToken() helper method
+
+        throw new IllegalStateException("Not yet implemented");
+    }
+
     /**
      * Acquires security token from the authority.
      *
@@ -856,6 +866,13 @@ public class AuthenticationContext {
                 authGrant = new AdalAuthorizatonGrant(updatedGrant,
                         authGrant.getCustomParameters());
             }
+        }
+        else if (authGrant.getAuthorizationGrant() instanceof InteractiveAuthorizationGrant) {
+            InteractiveAuthorizationGrant grant = (InteractiveAuthorizationGrant) authGrant.getAuthorizationGrant();
+
+            // TODO: code = UserAgent#requestAuthorizationCode().getCode()
+            // TODO: authCodeGrant = new AuthorizationCodeGrant(code)
+            // TODO: authGrant = new AdalAuthorizationGrant(authCodeGrant, resource)
         }
 
         return authGrant;

--- a/src/main/java/com/microsoft/aad/adal4j/InteractiveAuthorizationGrant.java
+++ b/src/main/java/com/microsoft/aad/adal4j/InteractiveAuthorizationGrant.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright © Microsoft Open Technologies, Inc.
+ *
+ * All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ * ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+ * PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache License, Version 2.0 for the specific language
+ * governing permissions and limitations under the License.
+ ******************************************************************************/
+package com.microsoft.aad.adal4j;
+
+import com.nimbusds.oauth2.sdk.AuthorizationGrant;
+import com.nimbusds.oauth2.sdk.GrantType;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class InteractiveAuthorizationGrant extends AuthorizationGrant {
+
+    // TODO: add constructor parameters so we have enough state to do our job inside processPasswordGrant()
+    public InteractiveAuthorizationGrant() {
+        super(GrantType.AUTHORIZATION_CODE);
+    }
+
+    @Override
+    public Map<String, String> toParameters() {
+        final LinkedHashMap<String, String> params = new LinkedHashMap<String, String>();
+        return params;
+    }
+}

--- a/src/main/java/com/microsoft/aad/adal4j/PromptBehavior.java
+++ b/src/main/java/com/microsoft/aad/adal4j/PromptBehavior.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright © Microsoft Open Technologies, Inc.
+ *
+ * All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ * ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+ * PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache License, Version 2.0 for the specific language
+ * governing permissions and limitations under the License.
+ ******************************************************************************/
+package com.microsoft.aad.adal4j;
+
+/**
+ * Indicates whether acquireToken should automatically prompt only if necessary or whether
+ * it should prompt regardless of whether there is a cached token.
+ */
+public enum PromptBehavior {
+    /**
+     * Acquire token will prompt the user for credentials only when necessary.  If a token
+     * that meets the requirements is already cached then the user will not be prompted.
+     */
+    AUTO,
+
+    /**
+     * The user will be prompted for credentials even if there is a token that meets the requirements
+     * already in the cache.
+     */
+    ALWAYS,
+
+    /**
+     * The user will not be prompted for credentials.  If prompting is necessary then the acquireToken request
+     * will fail.
+     */
+    NEVER,
+
+    /**
+     * Not yet implemented. Reserved for future use.
+     */
+    /*
+     * Re-authorizes (through displaying browser) the resource usage, making sure that the resulting access
+     * token contains updated claims. If user logon cookies are available, the user will not be asked for
+     * credentials again and the logon dialog will dismiss automatically.
+     */
+    REFRESH_SESSION,
+    ;
+}

--- a/src/main/java/com/microsoft/aad/adal4j/UserIdentifier.java
+++ b/src/main/java/com/microsoft/aad/adal4j/UserIdentifier.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright © Microsoft Open Technologies, Inc.
+ *
+ * All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ * ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+ * PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache License, Version 2.0 for the specific language
+ * governing permissions and limitations under the License.
+ ******************************************************************************/
+package com.microsoft.aad.adal4j;
+
+import java.util.Objects;
+
+/**
+ * Contains identifier for a user.
+ */
+public final class UserIdentifier {
+    private static final String ANY_USER_ID = "AnyUser";
+    /**
+     * A static instance of {@link UserIdentifier} to represent any user.
+     */
+    public static final UserIdentifier ANY_USER = new UserIdentifier(ANY_USER_ID, UserIdentifierType.UNIQUE_ID);
+
+    private final String id;
+    private final UserIdentifierType type;
+
+    public UserIdentifier(final String id, final UserIdentifierType type) {
+        if (StringHelper.isBlank(id)) {
+            throw new IllegalArgumentException("id is null or empty");
+        }
+        this.id = id;
+        this.type = type;
+    }
+
+    /**
+     * @return the type of the {@link UserIdentifier}.
+     */
+    public UserIdentifierType getType() {
+        return this.type;
+    }
+
+    /**
+     * @return id of the {@link UserIdentifier}.
+     */
+    public String getId() {
+        return this.id;
+    }
+
+    boolean isAnyUser() {
+        return this.type == ANY_USER.type && Objects.equals(this.id, ANY_USER.id);
+    }
+
+    String getUniqueId() {
+        return (!this.isAnyUser() && this.type == UserIdentifierType.UNIQUE_ID) ? this.id : null;
+    }
+
+    String getDisplayableId() {
+        return (!this.isAnyUser() && (this.type == UserIdentifierType.OPTIONAL_DISPLAYABLE_ID || this.type == UserIdentifierType.REQUIRED_DISPLAYABLE_ID)) ? this.id : null;
+    }
+}

--- a/src/main/java/com/microsoft/aad/adal4j/UserIdentifierType.java
+++ b/src/main/java/com/microsoft/aad/adal4j/UserIdentifierType.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright © Microsoft Open Technologies, Inc.
+ *
+ * All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ * ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+ * PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache License, Version 2.0 for the specific language
+ * governing permissions and limitations under the License.
+ ******************************************************************************/
+package com.microsoft.aad.adal4j;
+
+/**
+ * Indicates the type of {@link UserIdentifier}
+ */
+public enum UserIdentifierType {
+    /**
+     * When a {@link UserIdentifier} of this type is passed in a token acquisition operation,
+     * the operation is guaranteed to return a token issued for the user with corresponding
+     * {@link UserIdentifier#getUniqueId()} or fail.
+     */
+    UNIQUE_ID,
+
+    /**
+     * When a {@link UserIdentifier} of this type is passed in a token acquisition operation,
+     * the operation restricts cache matches to the value provided and injects it as a hint in the
+     * authentication experience. However the end user could overwrite that value, resulting in a token
+     * issued to a different account than the one specified in the {@link UserIdentifier} in input.
+     */
+    OPTIONAL_DISPLAYABLE_ID,
+
+    /**
+     * When a {@link UserIdentifier} of this type is passed in a token acquisition operation,
+     * the operation is guaranteed to return a token issued for the user with corresponding
+     * {@link UserIdentifier#getDisplayableId()} (UPN or email) or fail
+     */
+    REQUIRED_DISPLAYABLE_ID,
+    ;
+}


### PR DESCRIPTION
@lenala and I have been looking at rewriting the work that was originally submitted as pull request #20.

We think we found a way to lighten the dependency requirements for adding the interactive authentication feature through using the [oauth2-useragent library](https://github.com/Microsoft/oauth2-useragent).  Specifically, this component removes the need for a web server and for needing SWT at compile-time.  It currently uses JavaFX to launch a web browser on platforms that support it (Oracle Java 7 Update 6 & up, and Oracle Java 8) and eventually will add SWT support for platforms that don't support JavaFX, but the SWT dependencies would be the responsibility of program builders, which they could pass on to end-users.  The point is, with this approach, SWT won't be added to ADAL4J's dependencies, reducing the impact for non-interactive consumers/users.

This PR is currently a rough outline of the proposed changes.  Before we go any further with the implementation, we wanted to run it by your team.  Commit ba085fa is where most of the proposed changes lie, in the form of TODOs.  There are a few open questions as to the best/most elegant way to approach/implement this (specifically the use of the proposed `InteractiveAuthorizationGrant` so we can re-use the private `acquireToken()` helper method, when should the `UserAgent` implementation be created and so on), so your feedback would be greatly appreciated.

Please let us know how we can best be successful at adding interactive authentication & authorization so that it can land in, say, version 1.2 of ADAL4J.

Thanks!
