### PR TITLE
Java 6 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,8 +154,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/com/microsoft/aad/adal4j/AdalOAuthRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AdalOAuthRequest.java
@@ -120,7 +120,7 @@ class AdalOAuthRequest extends HTTPRequest {
             conn.setRequestProperty("Authorization", this.getAuthorization());
         }
 
-        Map<String, String> params = new java.util.HashMap<>();
+        Map<String, String> params = new java.util.HashMap<String, String>();
         if (this.extraHeaderParams != null && !this.extraHeaderParams.isEmpty()) {
             for (java.util.Map.Entry<String, String> entry : this.extraHeaderParams
                     .entrySet()) {

--- a/src/test/java/com/microsoft/aad/adal4j/MexParserTest.java
+++ b/src/test/java/com/microsoft/aad/adal4j/MexParserTest.java
@@ -53,7 +53,7 @@ public class MexParserTest {
 
             while (line != null) {
                 sb.append(line);
-                sb.append(String.format("%n"));
+                sb.append(System.getProperty("line.separator"));
                 line = br.readLine();
             }
         } finally {
@@ -80,7 +80,7 @@ public class MexParserTest {
 
             while (line != null) {
                 sb.append(line);
-                sb.append(String.format("%n"));
+                sb.append(System.getProperty("line.separator"));
                 line = br.readLine();
             }
         } finally {

--- a/src/test/java/com/microsoft/aad/adal4j/MexParserTest.java
+++ b/src/test/java/com/microsoft/aad/adal4j/MexParserTest.java
@@ -44,15 +44,21 @@ public class MexParserTest {
     public void testMexParsing() throws Exception {
 
         StringBuilder sb = new StringBuilder();
-        try (BufferedReader br = new BufferedReader(new FileReader(
+        BufferedReader br = null;
+        try {
+            br  = new BufferedReader(new FileReader(
                 (this.getClass().getResource(
-                        TestConfiguration.AAD_MEX_RESPONSE_FILE).getFile())))) {
+                    TestConfiguration.AAD_MEX_RESPONSE_FILE).getFile())));
             String line = br.readLine();
 
             while (line != null) {
                 sb.append(line);
-                sb.append(System.lineSeparator());
+                sb.append(String.format("%n"));
                 line = br.readLine();
+            }
+        } finally {
+            if (br != null){
+                br.close();
             }
         }
         BindingPolicy endpoint = MexParser.getWsTrustEndpointFromMexResponse(sb
@@ -65,15 +71,21 @@ public class MexParserTest {
     public void testMexParsingWs2005() throws Exception {
 
         StringBuilder sb = new StringBuilder();
-        try (BufferedReader br = new BufferedReader(new FileReader(
+        BufferedReader br = null;
+        try {
+            br = new BufferedReader(new FileReader(
                 this.getClass().getResource(
-                TestConfiguration.AAD_MEX_2005_RESPONSE_FILE).getFile()))) {
+                    TestConfiguration.AAD_MEX_2005_RESPONSE_FILE).getFile()));
             String line = br.readLine();
 
             while (line != null) {
                 sb.append(line);
-                sb.append(System.lineSeparator());
+                sb.append(String.format("%n"));
                 line = br.readLine();
+            }
+        } finally {
+            if (br != null) {
+                br.close();
             }
         }
         BindingPolicy endpoint = MexParser.getWsTrustEndpointFromMexResponse(sb

--- a/src/test/java/com/microsoft/aad/adal4j/WSTrustResponseTest.java
+++ b/src/test/java/com/microsoft/aad/adal4j/WSTrustResponseTest.java
@@ -43,15 +43,21 @@ public class WSTrustResponseTest {
     @Test
     public void testWSTrustResponseParseSuccess() throws Exception {
         StringBuilder sb = new StringBuilder();
-        try (BufferedReader br = new BufferedReader(new FileReader((this
+        BufferedReader br = null;
+        try {
+            br = new BufferedReader(new FileReader((this
                 .getClass().getResource(
-                        TestConfiguration.AAD_TOKEN_SUCCESS_FILE).getFile())))) {
+                    TestConfiguration.AAD_TOKEN_SUCCESS_FILE).getFile())));
             String line = br.readLine();
 
             while (line != null) {
                 sb.append(line);
-                sb.append(System.lineSeparator());
+                sb.append(String.format("%n"));
                 line = br.readLine();
+            }
+        } finally {
+            if (br != null) {
+                br.close();
             }
         }
         WSTrustResponse response = WSTrustResponse.parse(sb.toString(), WSTrustVersion.WSTRUST13);
@@ -62,15 +68,20 @@ public class WSTrustResponseTest {
     public void testWSTrustResponseParseError() throws Exception {
 
         StringBuilder sb = new StringBuilder();
-        try (BufferedReader br = new BufferedReader(new FileReader(
-                (this.getClass().getResource(
-                        TestConfiguration.AAD_TOKEN_ERROR_FILE).getFile())))) {
+        BufferedReader br = new BufferedReader(new FileReader(
+            (this.getClass().getResource(
+                TestConfiguration.AAD_TOKEN_ERROR_FILE).getFile())));
+        try {
             String line = br.readLine();
 
             while (line != null) {
                 sb.append(line);
-                sb.append(System.lineSeparator());
+                sb.append(String.format("%n"));
                 line = br.readLine();
+            }
+        } finally {
+            if (br != null) {
+                br.close();
             }
         }
         WSTrustResponse response = WSTrustResponse.parse(sb.toString(), WSTrustVersion.WSTRUST13);

--- a/src/test/java/com/microsoft/aad/adal4j/WSTrustResponseTest.java
+++ b/src/test/java/com/microsoft/aad/adal4j/WSTrustResponseTest.java
@@ -52,7 +52,7 @@ public class WSTrustResponseTest {
 
             while (line != null) {
                 sb.append(line);
-                sb.append(String.format("%n"));
+                sb.append(System.getProperty("line.separator"));
                 line = br.readLine();
             }
         } finally {
@@ -76,7 +76,7 @@ public class WSTrustResponseTest {
 
             while (line != null) {
                 sb.append(line);
-                sb.append(String.format("%n"));
+                sb.append(System.getProperty("line.separator"));
                 line = br.readLine();
             }
         } finally {


### PR DESCRIPTION
Some users still need to use Java 6.  With the minor changes in this pull request, the library can be used with Java 6.

I did not convert the samples from Java 7 to Java 6