### PR TITLE
Use confidential client for on behalf-of flow

### DIFF
--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -19,6 +19,7 @@
  ******************************************************************************/
 package com.microsoft.aad.adal4j;
 
+import javax.net.ssl.SSLSocketFactory;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.Proxy;
@@ -31,12 +32,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-
-import javax.net.ssl.SSLSocketFactory;
-
-import org.apache.commons.codec.binary.Base64;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.SignedJWT;
@@ -57,6 +52,9 @@ import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
+import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The main class representing the authority issuing tokens for resources. It
@@ -142,7 +140,7 @@ public class AuthenticationContext {
     /**
      * Sets SSLSocketFactory object to be used by the context.
      * 
-     * @param sslSocketFactory
+     * @param sslSocketFactory The SSL factory object to set
      */
     public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
         this.sslSocketFactory = sslSocketFactory;
@@ -255,6 +253,54 @@ public class AuthenticationContext {
     }
 
     /**
+     * Acquires a security token from authority using an authenticated client with password credential
+     * grant.
+     *
+     * @param resource
+     *            Identifier of the target resource that is the recipient of the
+     *            requested token. If null, token is requested for the same
+     *            resource refresh token was originally issued for. If passed,
+     *            resource should match the original resource used to acquire
+     *            refresh token unless token service supports refresh token for
+     *            multiple resources.
+      @param credential
+     *            object representing Private Key to use for token acquisition.
+     * @param username
+     *            Username of the managed or federated user.
+     * @param password
+     *            Password of the managed or federated user.
+     * @param callback
+     *            optional callback object for non-blocking execution.
+     * @return A {@link Future} object representing the
+     *         {@link AuthenticationResult} of the call. It contains Access
+     *         Token, Refresh Token and the Access Token's expiration time.
+     */
+    public Future<AuthenticationResult> acquireToken(final String resource,
+                                                     final AsymmetricKeyCredential credential,
+                                                     final String username,
+                                                     final String password,
+                                                     final AuthenticationCallback callback) {
+        if (StringHelper.isBlank(resource)) {
+            throw new IllegalArgumentException("resource is null or empty");
+        }
+
+        if (StringHelper.isBlank(username)) {
+            throw new IllegalArgumentException("username is null or empty");
+        }
+
+        if (StringHelper.isBlank(password)) {
+            throw new IllegalArgumentException("password is null or empty");
+        }
+
+        ClientAssertion assertion = JwtHelper.buildJwt(credential, this.authenticationAuthority.getSelfSignedJwtAudience());
+        final ClientAuthentication clientAuth = createClientAuthFromClientAssertion(assertion);
+        final AdalAuthorizatonGrant authGrant = new AdalAuthorizatonGrant(
+                new ResourceOwnerPasswordCredentialsGrant(username, new Secret(password)), resource);
+
+        return this.acquireToken(authGrant, clientAuth, callback);
+    }
+    
+    /**
      * Acquires security token from the authority.
      *
      * @param resource
@@ -307,7 +353,7 @@ public class AuthenticationContext {
      *         {@link AuthenticationResult} of the call. It contains Access
      *         Token and the Access Token's expiration time. Refresh Token
      *         property will be null for this overload.
-     * @throws AuthenticationException
+     * @throws AuthenticationException {@link AuthenticationException}
      */
     public Future<AuthenticationResult> acquireToken(final String resource,
             final ClientAssertion assertion, final ClientCredential credential,
@@ -373,7 +419,7 @@ public class AuthenticationContext {
      *         {@link AuthenticationResult} of the call. It contains Access
      *         Token and the Access Token's expiration time. Refresh Token
      *         property will be null for this overload.
-     * @throws AuthenticationException
+     * @throws AuthenticationException {@link AuthenticationException}
      */
     public Future<AuthenticationResult> acquireToken(final String resource,
             final AsymmetricKeyCredential credential,


### PR DESCRIPTION
We have a use case in the integration tests where a token needs to be acquired automatically with user context  from login.window.net authority. The token is then used to test the authorization logic which is implemented in the resource server. 

Unfortunately the login.window.net authority supports only confidential clients, for this reason we can not use the existing implementation for public clients. The confidential clients are anyhow more secure than public clients, so please consider this addition to the public API. 
