### PR TITLE
acquireToken by providing clientId, clientSecret, username, password

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>adal4j</artifactId>
-	<version>1.1.3</version>
+	<version>1.1.4-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>adal4j</name>
 	<description>
@@ -32,6 +32,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<!-- github server corresponds to entry in ~/.m2/settings.xml -->
+		<github.global.server>github</github.global.server>
 	</properties>
 
 	<profiles>
@@ -172,7 +174,8 @@
 						<format>xml</format>
 						<format>html</format>
 					</formats>
-				</configuration>
+                    <check/>
+                </configuration>
 				<dependencies>
 					<dependency>
 						<groupId>com.sun</groupId>
@@ -209,6 +212,46 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.8.2</version>
+				<configuration>
+					<altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
+				</configuration>
+			</plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.12</version>
+                <configuration>
+                    <message>Maven artifacts for ${project.version}</message>
+                    <noJekyll>true</noJekyll>
+                    <outputDirectory>${project.build.directory}/mvn-repo
+                    </outputDirectory>
+                    <branch>refs/heads/mvn-repo</branch>
+                    <includes>
+                        <include>**/*</include>
+                    </includes>
+                    <repositoryName>azure-activedirectory-library-for-java</repositoryName>
+                    <repositoryOwner>zzeekk</repositoryOwner>
+                    <server>github</server>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
+	<distributionManagement>
+		<repository>
+			<id>internal.repo</id>
+			<name>Temporary Staging Repository</name>
+			<url>file://${project.build.directory}/mvn-repo</url>
+		</repository>
+	</distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>adal4j</artifactId>
-	<version>1.1.4-SNAPSHOT</version>
+	<version>1.1.4-SNAP</version>
 	<packaging>jar</packaging>
 	<name>adal4j</name>
 	<description>
@@ -32,8 +32,6 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<!-- github server corresponds to entry in ~/.m2/settings.xml -->
-		<github.global.server>github</github.global.server>
 	</properties>
 
 	<profiles>
@@ -212,46 +210,13 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
-				<configuration>
-					<altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
-				</configuration>
-			</plugin>
-            <plugin>
-                <groupId>com.github.github</groupId>
-                <artifactId>site-maven-plugin</artifactId>
-                <version>0.12</version>
-                <configuration>
-                    <message>Maven artifacts for ${project.version}</message>
-                    <noJekyll>true</noJekyll>
-                    <outputDirectory>${project.build.directory}/mvn-repo
-                    </outputDirectory>
-                    <branch>refs/heads/mvn-repo</branch>
-                    <includes>
-                        <include>**/*</include>
-                    </includes>
-                    <repositoryName>azure-activedirectory-library-for-java</repositoryName>
-                    <repositoryOwner>zzeekk</repositoryOwner>
-                    <server>github</server>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>site</goal>
-                        </goals>
-                        <phase>deploy</phase>
-                    </execution>
-                </executions>
-            </plugin>
 		</plugins>
 	</build>
-	<distributionManagement>
-		<repository>
-			<id>internal.repo</id>
-			<name>Temporary Staging Repository</name>
-			<url>file://${project.build.directory}/mvn-repo</url>
-		</repository>
-	</distributionManagement>
+   <distributionManagement>
+                <repository>
+                <id>bintray-zach-zzeekk-snapshot</id>
+                <name>Zach-zzeekk-snapshot</name>
+                <url>https://api.bintray.com/maven/zach/zzeekk-snapshot/azure-activedirectory-library-for-java;publish=1</url>
+                </repository>
+   </distributionManagement>
 </project>

--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -255,6 +255,63 @@ public class AuthenticationContext {
     }
 
     /**
+     * Acquires a security token from the authority using a Refresh Token
+     * previously received.
+     *
+     * @param resource
+     *            Identifier of the target resource that is the recipient of the
+     *            requested token. If null, token is requested for the same
+     *            resource refresh token was originally issued for. If passed,
+     *            resource should match the original resource used to acquire
+     *            refresh token unless token service supports refresh token for
+     *            multiple resources.
+     * @param clientId
+     *            Name or ID of the client requesting the token.
+     * @param clientSecret
+     *            Secret of the client requesting the token.
+     * @param username
+     *            Username of the managed or federated user.
+     * @param password
+     *            Password of the managed or federated user.
+     * @param callback
+     *            optional callback object for non-blocking execution.
+     * @return A {@link Future} object representing the
+     *         {@link AuthenticationResult} of the call. It contains Access
+     *         Token, Refresh Token and the Access Token's expiration time.
+     */
+    public Future<AuthenticationResult> acquireToken(final String resource,
+                                                     final String clientId, final String clientSecret,
+                                                     final String username, final String password,
+                                                     final AuthenticationCallback callback) {
+        if (StringHelper.isBlank(resource)) {
+            throw new IllegalArgumentException("resource is null or empty");
+        }
+
+        if (StringHelper.isBlank(clientId)) {
+            throw new IllegalArgumentException("clientId is null or empty");
+        }
+
+        if (StringHelper.isBlank(clientSecret)) {
+            throw new IllegalArgumentException("clientSecret is null or empty");
+        }
+
+        if (StringHelper.isBlank(username)) {
+            throw new IllegalArgumentException("username is null or empty");
+        }
+
+        if (StringHelper.isBlank(password)) {
+            throw new IllegalArgumentException("password is null or empty");
+        }
+
+        return this.acquireToken(new AdalAuthorizatonGrant(
+                        new ResourceOwnerPasswordCredentialsGrant(username, new Secret(
+                                password)), resource), new ClientAuthenticationPost(
+                        ClientAuthenticationMethod.NONE, new ClientID(clientId), clientSecret),
+                callback);
+    }
+
+
+    /**
      * Acquires security token from the authority.
      *
      * @param resource

--- a/src/main/java/com/microsoft/aad/adal4j/ClientAuthenticationPost.java
+++ b/src/main/java/com/microsoft/aad/adal4j/ClientAuthenticationPost.java
@@ -34,9 +34,17 @@ import com.nimbusds.oauth2.sdk.util.URLUtils;
 
 class ClientAuthenticationPost extends ClientAuthentication {
 
+    String clientSecret;
+
     protected ClientAuthenticationPost(ClientAuthenticationMethod method,
             ClientID clientID) {
         super(method, clientID);
+    }
+
+    protected ClientAuthenticationPost(ClientAuthenticationMethod method,
+                                       ClientID clientID, String clientSecret) {
+        super(method, clientID);
+        this.clientSecret = clientSecret;
     }
 
     Map<String, String> toParameters() {
@@ -44,6 +52,7 @@ class ClientAuthenticationPost extends ClientAuthentication {
         Map<String, String> params = new HashMap<String, String>();
 
         params.put("client_id", getClientID().getValue());
+        if (clientSecret!=null) params.put("client_secret", clientSecret);
 
         return params;
     }


### PR DESCRIPTION
I tried to use the PowerBI API with non-interactive authentication and the following acquireToken call:
_token = authContext.acquireToken(resourceUri, clientId, username, pw, null).get()_
This results in the following error:
_com.microsoft.aad.adal4j.AuthenticationException: {"error_description":"AADSTS90014: The request body must contain the following parameter: 'client_secret or client_assertion'.\r\nTrace ID: dd5f457c-9bd0-4f3f-a999-74f9c539f544\r\nCorrelation ID: 961ed1cc-fea3-4217-88bb-f361b9b2e267\r\nTimestamp: 2016-08-14 06:57:16Z","error":"invalid_request"}_

Currently an acquireToken method with parameters clientId, clientSecret, username, password is missing. This pull-request fixes this and makes it possible to get a Token which can be used with PowerBI API.
