### PR TITLE
Remove unsafe casting to java.security.RSAPrivateKey when not necessary

### DIFF
--- a/src/main/java/com/microsoft/aad/adal4j/AsymmetricKeyCredential.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AsymmetricKeyCredential.java
@@ -70,7 +70,7 @@ public final class AsymmetricKeyCredential {
         this.clientId = clientId;
         this.key = key;
 
-        if (((RSAPrivateKey) key).getModulus().bitLength() < MIN_KEYSIZE_IN_BITS) {
+        if (key instanceof  RSAPrivateKey && ((RSAPrivateKey) key).getModulus().bitLength() < MIN_KEYSIZE_IN_BITS) {
             throw new IllegalArgumentException(
                     "certificate key size must be at least "
                             + MIN_KEYSIZE_IN_BITS);

--- a/src/main/java/com/microsoft/aad/adal4j/JwtHelper.java
+++ b/src/main/java/com/microsoft/aad/adal4j/JwtHelper.java
@@ -19,7 +19,7 @@
  ******************************************************************************/
 package com.microsoft.aad.adal4j;
 
-import java.security.interfaces.RSAPrivateKey;
+import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -73,7 +73,7 @@ final class JwtHelper {
                     .getPublicCertificateHash()));
             jwt = new SignedJWT(builder.build(), claimsSet);
             final RSASSASigner signer = new RSASSASigner(
-                    (RSAPrivateKey) credential.getKey());
+                    (PrivateKey) credential.getKey());
 
             jwt.sign(signer);
         }


### PR DESCRIPTION
Proposal to fix "Fails to create a AsymmetricKeyCredential from a windows store certificate" #110. Please note that I remove a check that may be important.