### PR TITLE
adding support for RSA keys produced by SunMSCAPI provider

### DIFF
--- a/src/main/java/com/microsoft/aad/adal4j/JwtHelper.java
+++ b/src/main/java/com/microsoft/aad/adal4j/JwtHelper.java
@@ -19,7 +19,6 @@
  ******************************************************************************/
 package com.microsoft.aad.adal4j;
 
-import java.security.interfaces.RSAPrivateKey;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -72,8 +71,7 @@ final class JwtHelper {
             builder.x509CertThumbprint(new Base64URL(credential
                     .getPublicCertificateHash()));
             jwt = new SignedJWT(builder.build(), claimsSet);
-            final RSASSASigner signer = new RSASSASigner(
-                    (RSAPrivateKey) credential.getKey());
+            final RSASSASigner signer = new RSASSASigner(credential.getKey());
 
             jwt.sign(signer);
         }


### PR DESCRIPTION
Adding support of RSA keys produced by SunMSCAPI provider (nables applications to use the standard JCA/JCE APIs to access the native cryptographic libraries, certificates stores and key containers on the Microsoft Windows platform)

RSA private keys generated by the SunMSCAPI provider cannot be serialized and implement the java.security.PrivateKey interface instead of the java.security.interfaces.RSAPrivateKey interface