### PR TITLE
Remove hard-coded client ID in public client sample

### DIFF
--- a/src/samples/public-client-app-sample/src/main/java/PublicClient.java
+++ b/src/samples/public-client-app-sample/src/main/java/PublicClient.java
@@ -11,8 +11,9 @@ import com.microsoft.aad.adal4j.AuthenticationResult;
 
 public class PublicClient {
 
-    private final static String AUTHORITY = "https://login.windows.net/common";
-    private final static String CLIENT_ID = "9ba1a5c7-f17a-4de9-a1f1-6178c8d51223";
+    private final static String AUTHORITY = "https://login.microsoftonline.com/common";
+    private final static String CLIENT_ID = "YOUR_PUBLIC_CLIENT_ID";
+    private final static String RESOURCE = "https://graph.windows.net";
 
     public static void main(String args[]) throws Exception {
 
@@ -40,8 +41,7 @@ public class PublicClient {
             service = Executors.newFixedThreadPool(1);
             context = new AuthenticationContext(AUTHORITY, false, service);
             Future<AuthenticationResult> future = context.acquireToken(
-                    "https://graph.windows.net", CLIENT_ID, username, password,
-                    null);
+                    RESOURCE, CLIENT_ID, username, password, null);
             result = future.get();
         } finally {
             service.shutdown();


### PR DESCRIPTION
Removes the hard-coded client ID from the public client sample. Developers should register their own native client application to use for the sample.