### PR TITLE
Update nimbus sdk to version 5.24.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>com.nimbusds</groupId>
 			<artifactId>oauth2-oidc-sdk</artifactId>
-			<version>5.18.1</version>
+			<version>5.24.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
This is the latest version of nimbus sdk which has a fix for this critical vulnerability in JOSE encryption. 

https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.nimbusds%22%20AND%20a%3A%22oauth2-oidc-sdk%22

http://blogs.adobe.com/security/2017/03/critical-vulnerability-uncovered-in-json-encryption.html

cc @SomkaPe @kpanwar @psignoret
