### PR TITLE
Fixes #51 java doc issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Stories in Ready](https://badge.waffle.io/AzureAD/azure-activedirectory-library-for-java.png?label=ready&title=Ready)](https://waffle.io/AzureAD/azure-activedirectory-library-for-java)
-#Microsoft Azure Active Directory Authentication Library (ADAL) for Java
+[![Javadocs](http://javadoc.io/badge/com.microsoft.azure/adal4j.svg)](http://javadoc.io/doc/com.microsoft.azure/adal4j)
+</br>
+# Microsoft Azure Active Directory Authentication Library (ADAL) for Java
 =====================================
 
 ## Samples and Documentation
@@ -28,3 +30,4 @@ All code is licensed under the Apache 2.0 license and we triage actively on GitH
 ## We Value and Adhere to the Microsoft Open Source Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+


### PR DESCRIPTION
As we are doing maven release we generally create java docs. Open source
project can take advantage of javadoc.io for hosting javadocs.