### PR TITLE
Added hashCode & equals method

### DIFF
--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationResult.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationResult.java
@@ -21,6 +21,7 @@ package com.microsoft.aad.adal4j;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 
 /**
  * Contains the results of one token acquisition operation.
@@ -97,4 +98,57 @@ public final class AuthenticationResult implements Serializable {
     public boolean isMultipleResourceRefreshToken() {
         return isMultipleResourceRefreshToken;
     }
+    
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 41 * hash + Objects.hashCode(this.accessTokenType);
+        hash = 41 * hash + (int) (this.expiresIn ^ (this.expiresIn >>> 32));
+        hash = 41 * hash + Objects.hashCode(this.expiresOn);
+        hash = 41 * hash + Objects.hashCode(this.idToken);
+        hash = 41 * hash + Objects.hashCode(this.userInfo);
+        hash = 41 * hash + Objects.hashCode(this.accessToken);
+        hash = 41 * hash + Objects.hashCode(this.refreshToken);
+        hash = 41 * hash + (this.isMultipleResourceRefreshToken ? 1 : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final AuthenticationResult other = (AuthenticationResult) obj;
+        if (this.expiresIn != other.expiresIn) {
+            return false;
+        }
+        if (this.isMultipleResourceRefreshToken != other.isMultipleResourceRefreshToken) {
+            return false;
+        }
+        if (!Objects.equals(this.accessTokenType, other.accessTokenType)) {
+            return false;
+        }
+        if (!Objects.equals(this.idToken, other.idToken)) {
+            return false;
+        }
+        if (!Objects.equals(this.accessToken, other.accessToken)) {
+            return false;
+        }
+        if (!Objects.equals(this.refreshToken, other.refreshToken)) {
+            return false;
+        }
+        if (!Objects.equals(this.expiresOn, other.expiresOn)) {
+            return false;
+        }
+        if (!Objects.equals(this.userInfo, other.userInfo)) {
+            return false;
+        }
+        return true;
+    }    
 }

--- a/src/main/java/com/microsoft/aad/adal4j/ClientAssertion.java
+++ b/src/main/java/com/microsoft/aad/adal4j/ClientAssertion.java
@@ -20,6 +20,7 @@
 package com.microsoft.aad.adal4j;
 
 import com.nimbusds.oauth2.sdk.auth.JWTAuthentication;
+import java.util.Objects;
 
 /***
  * Credential type containing an assertion of type
@@ -53,4 +54,29 @@ public final class ClientAssertion {
     public String getAssertionType() {
         return assertionType;
     }
+    
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 97 * hash + Objects.hashCode(this.assertion);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ClientAssertion other = (ClientAssertion) obj;
+        if (!Objects.equals(this.assertion, other.assertion)) {
+            return false;
+        }
+        return true;
+    }    
 }

--- a/src/main/java/com/microsoft/aad/adal4j/ClientCredential.java
+++ b/src/main/java/com/microsoft/aad/adal4j/ClientCredential.java
@@ -19,6 +19,8 @@
  ******************************************************************************/
 package com.microsoft.aad.adal4j;
 
+import java.util.Objects;
+
 /**
  * Credential including client id and secret.
  */
@@ -65,4 +67,33 @@ public final class ClientCredential {
     public String getClientSecret() {
         return clientSecret;
     }
+    
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 71 * hash + Objects.hashCode(this.clientId);
+        hash = 71 * hash + Objects.hashCode(this.clientSecret);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ClientCredential other = (ClientCredential) obj;
+        if (!Objects.equals(this.clientId, other.clientId)) {
+            return false;
+        }
+        if (!Objects.equals(this.clientSecret, other.clientSecret)) {
+            return false;
+        }
+        return true;
+    }    
 }

--- a/src/main/java/com/microsoft/aad/adal4j/UserInfo.java
+++ b/src/main/java/com/microsoft/aad/adal4j/UserInfo.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 
 import com.nimbusds.jwt.JWTClaimsSet;
+import java.util.*;
 
 /**
  * Contains information of a single user.
@@ -160,4 +161,52 @@ public class UserInfo implements Serializable {
         return userInfo;
     }
 
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 37 * hash + Objects.hashCode(this.uniqueId);
+        hash = 37 * hash + Objects.hashCode(this.displayableId);
+        hash = 37 * hash + Objects.hashCode(this.givenName);
+        hash = 37 * hash + Objects.hashCode(this.familyName);
+        hash = 37 * hash + Objects.hashCode(this.identityProvider);
+        hash = 37 * hash + Objects.hashCode(this.passwordChangeUrl);
+        hash = 37 * hash + Objects.hashCode(this.passwordExpiresOn);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final UserInfo other = (UserInfo) obj;
+        if (!Objects.equals(this.uniqueId, other.uniqueId)) {
+            return false;
+        }
+        if (!Objects.equals(this.displayableId, other.displayableId)) {
+            return false;
+        }
+        if (!Objects.equals(this.givenName, other.givenName)) {
+            return false;
+        }
+        if (!Objects.equals(this.familyName, other.familyName)) {
+            return false;
+        }
+        if (!Objects.equals(this.identityProvider, other.identityProvider)) {
+            return false;
+        }
+        if (!Objects.equals(this.passwordChangeUrl, other.passwordChangeUrl)) {
+            return false;
+        }
+        if (!Objects.equals(this.passwordExpiresOn, other.passwordExpiresOn)) {
+            return false;
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
Added hashCode and equals methods for use in HashMaps, Collections, and other scenarios where comparisons need to be made. These classes are public yet didn't override the default methods so comparing them was not possible. For instance

`AuthenticationResult ar1 = new  AuthenticationResult("accessTokenType", "accessToken", "refreshToken", 0, "idToken", null, true);`
`AuthenticationResult ar2 = new  AuthenticationResult("accessTokenType", "accessToken", "refreshToken", 0, "idToken", null, true);`
`Assert.assertEquals(ar1, ar2);`

would fail before, now it will pass as expected.