### PR TITLE
adding tenant id to User Info

### DIFF
--- a/src/main/java/com/microsoft/aad/adal4j/UserInfo.java
+++ b/src/main/java/com/microsoft/aad/adal4j/UserInfo.java
@@ -43,6 +43,7 @@ public class UserInfo implements Serializable {
     String identityProvider;
     String passwordChangeUrl;
     Date passwordExpiresOn;
+    String tenantId;
 
     private UserInfo() {
     }
@@ -99,6 +100,15 @@ public class UserInfo implements Serializable {
         }
     }
 
+    /**
+     * Get tenant id
+     *
+     * @return String value
+     */
+    public String getTenantId() {
+        return tenantId;
+    }
+
     static UserInfo createFromIdTokenClaims(final JWTClaimsSet claims)
             throws java.text.ParseException {
 
@@ -140,6 +150,8 @@ public class UserInfo implements Serializable {
                 .getStringClaim(AuthenticationConstants.ID_TOKEN_GIVEN_NAME);
         userInfo.identityProvider = claims
                 .getStringClaim(AuthenticationConstants.ID_TOKEN_IDENTITY_PROVIDER);
+        userInfo.tenantId = claims
+                .getStringClaim(AuthenticationConstants.ID_TOKEN_TENANTID);
 
         if (!StringHelper
                 .isBlank(claims

--- a/src/test/java/com/microsoft/aad/adal4j/UserInfoTest.java
+++ b/src/test/java/com/microsoft/aad/adal4j/UserInfoTest.java
@@ -95,6 +95,9 @@ public class UserInfoTest extends AbstractAdalTests {
         EasyMock.expect(
                 claimSet.getClaim(AuthenticationConstants.ID_TOKEN_PASSWORD_EXPIRES_ON))
                 .andReturn("5000").times(2);
+        EasyMock.expect(
+                claimSet.getStringClaim(AuthenticationConstants.ID_TOKEN_TENANTID))
+                .andReturn("TenantID").times(1);
 
         EasyMock.replay(claimSet);
         final UserInfo ui = UserInfo.createFromIdTokenClaims(claimSet);
@@ -105,6 +108,8 @@ public class UserInfoTest extends AbstractAdalTests {
         Assert.assertEquals("value", ui.getFamilyName());
         Assert.assertEquals("idp", ui.getIdentityProvider());
         Assert.assertEquals("url", ui.getPasswordChangeUrl());
+        Assert.assertEquals("TenantID", ui.getTenantId());
+
         Assert.assertNotNull(ui.getPasswordExpiresOn());
         PowerMock.verifyAll();
     }
@@ -144,6 +149,9 @@ public class UserInfoTest extends AbstractAdalTests {
         EasyMock.expect(
                 claimSet.getClaim(AuthenticationConstants.ID_TOKEN_PASSWORD_EXPIRES_ON))
                 .andReturn(null).times(1);
+        EasyMock.expect(
+                claimSet.getStringClaim(AuthenticationConstants.ID_TOKEN_TENANTID))
+                .andReturn("TenantID").times(1);
 
         EasyMock.replay(claimSet);
         final UserInfo ui = UserInfo.createFromIdTokenClaims(claimSet);
@@ -155,6 +163,7 @@ public class UserInfoTest extends AbstractAdalTests {
         Assert.assertEquals("idp", ui.getIdentityProvider());
         Assert.assertNull(ui.getPasswordChangeUrl());
         Assert.assertNull(ui.getPasswordExpiresOn());
+        Assert.assertEquals("TenantID", ui.getTenantId());
         PowerMock.verifyAll();
     }
 }


### PR DESCRIPTION
UserInfo does not include tenant ID of tenant that issued access token  https://github.com/AzureAD/azure-activedirectory-library-for-java/issues/163