### PR TITLE
AAD Integrated Authentication on Windows, Linux and Mac

### DIFF
--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -29,6 +29,7 @@ import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
@@ -281,6 +282,62 @@ public class AuthenticationContext {
                 new ClientCredentialsGrant(), resource);
         return this.acquireToken(authGrant, clientAuth, callback);
     }
+    
+    
+    
+    
+    
+    
+    
+	public Future<AuthenticationResult> acquireTokenIntegrated(AuthenticationContext context, final String resource, final String clientId,
+			final AuthenticationCallback callback) {
+		try {
+			// User Realm Information Endpoint
+			String userRealmEndpoint = context.authenticationAuthority.getUserRealmEndpoint(URLEncoder.encode("testodbc@microsoft.com", "UTF-8"));
+			
+			// Get the realm information
+			UserDiscoveryResponse userRealmResponse = UserDiscoveryRequest.execute(userRealmEndpoint, this.proxy,
+					this.sslSocketFactory);
+
+			if (userRealmResponse.isAccountFederated()
+					&& "WSTrust".equalsIgnoreCase(userRealmResponse.getFederationProtocol())) {
+				
+				System.out.println("isAccountFederated!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+				
+				String mexURL = userRealmResponse.getFederationMetadataUrl();
+				String cloudAudienceUrn = userRealmResponse.getCloudAudienceUrn();
+
+				System.out.println("mexURL: " + mexURL);
+				System.out.println("cloudAudienceUrn: " + cloudAudienceUrn);
+				System.out.println("ActiveAuthUrl: " + userRealmResponse.getFederationActiveAuthUrl());
+				
+				
+				// Discover the policy for authentication using the Metadata Exchange Url.
+				// Get the WSTrust Token (Web Service Trust Token)
+				WSTrustResponse response = WSTrustRequest.execute(mexURL, cloudAudienceUrn, this.proxy,
+						this.sslSocketFactory);
+
+				// TODO : need to parse the response to get the SAML assertion token
+				// We need to parse the document to get the SAML assertion token
+				System.out.println("SAML version of Token: " + response.getTokenType());
+				System.out.println("the SAML Assertion token ???: " + response.getToken());
+				System.out.println(response.SAML1_ASSERTION);
+			}
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		
+		
+
+		return null;
+	}
+    
+    
+    
+    
+    
+    
 
     private void validateInput(final String resource, final Object credential,
             final boolean validateResource) {

--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -285,11 +285,7 @@ public class AuthenticationContext {
                 new ClientCredentialsGrant(), resource);
         return this.acquireToken(authGrant, clientAuth, callback);
     }
-    
-    
-    
-    
-    
+
     private Future<AuthenticationResult> acquireTokenIntegrated(String userName,
             final String resource,
             final ClientAuthentication clientAuth,
@@ -304,11 +300,6 @@ public class AuthenticationContext {
 
             @Override
             public AuthenticationResult call() throws Exception {
-
-               
-
-                System.out.println("acquireTokenIntegrated call()!!!!!!!!!!!!!!!!!");
-
                 AuthenticationResult result = null;
                 try {
                     AdalAuthorizatonGrant authGrant = new AdalAuthorizatonGrant(getAuthorizationGrantIntegrated(this.userName), this.resource);
@@ -334,9 +325,6 @@ public class AuthenticationContext {
                     final String resource,
                     final ClientAuthentication clientAuth,
                     final ClientDataHttpHeaders headers) {
-
-                System.out.println("acquireTokenIntegrated init()!!!!!!!!!!!!!!!!!");
-
                 this.userName = userName;
                 this.resource = resource;
                 this.clientAuth = clientAuth;
@@ -352,35 +340,22 @@ public class AuthenticationContext {
 
         String userRealmEndpoint = authenticationAuthority.getUserRealmEndpoint(URLEncoder.encode(userName, "UTF-8"));
 
-        System.out.println("userRealmEndpoint: " + userRealmEndpoint);
-
         // Get the realm information
         UserDiscoveryResponse userRealmResponse = UserDiscoveryRequest.execute(userRealmEndpoint, proxy, sslSocketFactory);
 
         if (userRealmResponse.isAccountFederated() && "WSTrust".equalsIgnoreCase(userRealmResponse.getFederationProtocol())) {
-
-            System.out.println("isAccountFederated!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-
             String mexURL = userRealmResponse.getFederationMetadataUrl();
             String cloudAudienceUrn = userRealmResponse.getCloudAudienceUrn();
-
-            System.out.println("mexURL: " + mexURL);
-            System.out.println("cloudAudienceUrn: " + cloudAudienceUrn);
-            // System.out.println("ActiveAuthUrl: " + userRealmResponse.getFederationActiveAuthUrl());
 
             // Discover the policy for authentication using the Metadata Exchange Url.
             // Get the WSTrust Token (Web Service Trust Token)
             WSTrustResponse wsTrustResponse = WSTrustRequest.execute(mexURL, cloudAudienceUrn, proxy, sslSocketFactory);
-
-            System.out.println("SAML version of Token: " + wsTrustResponse.getTokenType());
-            System.out.println("SAML Assertion token: " + wsTrustResponse.getToken());
 
             // Make the OAuth2 call to get the access Token.
             if (wsTrustResponse.isTokenSaml2()) {
                 updatedGrant = new SAML2BearerGrant(new Base64URL(Base64.encodeBase64String(wsTrustResponse.getToken().getBytes("UTF-8"))));
             }
             else {
-                System.out.println("SAML 1");
                 updatedGrant = new SAML11BearerGrant(new Base64URL(Base64.encodeBase64String(wsTrustResponse.getToken().getBytes())));
             }
         }
@@ -392,18 +367,10 @@ public class AuthenticationContext {
             final String resource,
             final String clientId,
             final AuthenticationCallback callback) {
-
-        System.out.println("resource: " + resource);
-
         ClientAuthenticationPost clientAuth = new ClientAuthenticationPost(ClientAuthenticationMethod.NONE, new ClientID(clientId));
 
         return this.acquireTokenIntegrated(userName, resource, clientAuth, callback);
     }
-    
-    
-    
-    
-    
 
     private void validateInput(final String resource, final Object credential,
             final boolean validateResource) {

--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -325,13 +325,11 @@ public class AuthenticationContext {
 				WSTrustResponse wsTrustResponse = WSTrustRequest.execute(mexURL, cloudAudienceUrn, this.proxy,
 						this.sslSocketFactory);
 
-				// TODO : need to parse the response to get the SAML assertion token
-				// We need to parse the document to get the SAML assertion token
-				System.out.println("SAML version of Token, wsTrustResponse.getTokenType(): " + wsTrustResponse.getTokenType());
-				System.out.println("wsTrustResponse.getToken(): " + wsTrustResponse.getToken());
+				System.out.println("SAML version of Token: " + wsTrustResponse.getTokenType());
+				System.out.println("SAML Assertion token: " + wsTrustResponse.getToken());
 				
 				
-				
+				//Make the OAuth2 call to get the access Token.
 				AuthorizationGrant updatedGrant = null;
 				
 				if (wsTrustResponse.isTokenSaml2()) {

--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -300,6 +300,8 @@ public class AuthenticationContext {
                 AuthenticationResult result = null;
                 try {
                     AdalAuthorizatonGrant authGrant = new AdalAuthorizatonGrant(getAuthorizationGrantIntegrated(this.userName), this.resource);
+
+                    // Make the OAuth2 call to get the access Token.
                     result = acquireTokenCommon(authGrant, this.clientAuth, this.headers);
                     logResult(result, headers);
                     if (callback != null) {
@@ -348,7 +350,6 @@ public class AuthenticationContext {
             // Get the WSTrust Token (Web Service Trust Token)
             WSTrustResponse wsTrustResponse = WSTrustRequest.execute(mexURL, cloudAudienceUrn, proxy, sslSocketFactory);
 
-            // Make the OAuth2 call to get the access Token.
             if (wsTrustResponse.isTokenSaml2()) {
                 updatedGrant = new SAML2BearerGrant(new Base64URL(Base64.encodeBase64String(wsTrustResponse.getToken().getBytes("UTF-8"))));
             }

--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -25,6 +25,7 @@ package com.microsoft.aad.adal4j;
 
 import javax.net.ssl.SSLSocketFactory;
 import java.io.UnsupportedEncodingException;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URI;
@@ -294,14 +295,23 @@ public class AuthenticationContext {
 	public Future<AuthenticationResult> acquireTokenIntegrated(AuthenticationContext context, final String resource, final String clientId,
 			final AuthenticationCallback callback) {
 		try {
-			
-			
-			NTSystem system = new NTSystem();
-			System.out.println("system.getDomain(): " + system.getDomain());
-			System.out.println("system.getName(): " + system.getName());
-			
+			//testodbc
+			String username = System.getenv("USERNAME");
+	        System.out.println("username: " + username);
+
+	        //DESKTOP-V15F5F6.redmond.corp.microsoft.com
+	        String hostname = InetAddress.getLocalHost().getCanonicalHostName();
+	        System.out.println("Hostname: " + hostname);
+	        
+	        if(null == username || null == hostname || !hostname.contains(".")) {
+	        	return null;
+	        }
+	        
+	        String userDomainName = username + hostname.substring(hostname.indexOf("."));
+	        System.out.println("userDomainName: " + userDomainName);
+
 			// User Realm Information Endpoint
-			String userRealmEndpoint = context.authenticationAuthority.getUserRealmEndpoint(URLEncoder.encode("testodbc@microsoft.com", "UTF-8"));
+			String userRealmEndpoint = context.authenticationAuthority.getUserRealmEndpoint(URLEncoder.encode(userDomainName, "UTF-8"));
 			
 			// Get the realm information
 			UserDiscoveryResponse userRealmResponse = UserDiscoveryRequest.execute(userRealmEndpoint, this.proxy,

--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -25,7 +25,6 @@ package com.microsoft.aad.adal4j;
 
 import javax.net.ssl.SSLSocketFactory;
 import java.io.UnsupportedEncodingException;
-import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URI;
@@ -53,12 +52,10 @@ import com.nimbusds.oauth2.sdk.SAML2BearerGrant;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.auth.ClientSecretPost;
-import com.nimbusds.oauth2.sdk.auth.JWTAuthentication;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
-import com.sun.security.auth.module.NTSystem;
 
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;

--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -246,6 +246,11 @@ public class AuthenticationContext {
             throw new IllegalArgumentException("username is null or empty");
         }
 
+        if (password == null) {
+            ClientAuthenticationPost clientAuth = new ClientAuthenticationPost(ClientAuthenticationMethod.NONE, new ClientID(clientId));
+            return this.acquireTokenIntegrated(username, resource, clientAuth, callback);
+        }
+
         if (StringHelper.isBlank(password)) {
             throw new IllegalArgumentException("password is null or empty");
         }
@@ -359,15 +364,6 @@ public class AuthenticationContext {
         }
 
         return updatedGrant;
-    }
-
-    public Future<AuthenticationResult> acquireTokenIntegrated(String userName,
-            final String resource,
-            final String clientId,
-            final AuthenticationCallback callback) {
-        ClientAuthenticationPost clientAuth = new ClientAuthenticationPost(ClientAuthenticationMethod.NONE, new ClientID(clientId));
-
-        return this.acquireTokenIntegrated(userName, resource, clientAuth, callback);
     }
 
     private void validateInput(final String resource, final Object credential,

--- a/src/main/java/com/microsoft/aad/adal4j/MexParser.java
+++ b/src/main/java/com/microsoft/aad/adal4j/MexParser.java
@@ -26,11 +26,13 @@ package com.microsoft.aad.adal4j;
 import javax.net.ssl.SSLSocketFactory;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.net.Proxy;
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -43,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 class MexParser {
 
@@ -57,6 +60,56 @@ class MexParser {
     private final static String RST_SOAP_ACTION_2005 = "http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue";
     private final static String SOAP_TRANSPORT_XPATH = "soap12:binding/@transport";
     private final static String SOAP_HTTP_TRANSPORT_VALUE = "http://schemas.xmlsoap.org/soap/http";
+    
+    
+    
+    
+    
+    
+    static BindingPolicy getPolicyFromMexResponseForIntegrated(String mexResponse) throws Exception {    	
+        DocumentBuilderFactory builderFactory = SafeDocumentBuilderFactory.createInstance();
+        builderFactory.setNamespaceAware(true);
+        DocumentBuilder builder = builderFactory.newDocumentBuilder();
+        Document xmlDocument = builder.parse(new ByteArrayInputStream(
+                mexResponse.getBytes(Charset.forName("UTF-8"))));
+
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NamespaceContextImpl nameSpace = new NamespaceContextImpl();
+        xPath.setNamespaceContext(nameSpace);
+        
+        
+        String xpathExpression = "//wsdl:definitions/wsp:Policy/wsp:ExactlyOne/wsp:All/http:NegotiateAuthentication";
+        
+        
+        Map<String, BindingPolicy> policies = selectIntegratedPoliciesWithExpression(
+                xmlDocument, xPath, xpathExpression);
+        
+
+
+        if (policies.isEmpty()) {
+            log.debug("No matching policies");
+            return null;
+        }
+        else {
+            Map<String, BindingPolicy> bindings = getMatchingBindings(
+                    xmlDocument, xPath, policies);
+
+            if (bindings.isEmpty()) {
+                log.debug("No matching bindings");
+                return null;
+            }
+            else {
+                getPortsForPolicyBindings(xmlDocument, xPath, bindings,
+                        policies);
+                return selectSingleMatchingPolicy(policies);
+            }
+        }
+    }
+    
+    
+    
+    
+    
 
     static BindingPolicy getWsTrustEndpointFromMexResponse(String mexResponse)
             throws Exception {
@@ -278,6 +331,22 @@ class MexParser {
         }
         return policies;
     }
+    
+    private static Map<String, BindingPolicy> selectIntegratedPoliciesWithExpression(
+            Document xmlDocument, XPath xPath, String xpathExpression)
+            throws XPathExpressionException {
+
+        Map<String, BindingPolicy> policies = new HashMap<String, BindingPolicy>();
+
+        NodeList nodeList = (NodeList) xPath.compile(xpathExpression).evaluate(
+                xmlDocument, XPathConstants.NODESET);
+        for (int i = 0; i < nodeList.getLength(); i++) {
+        	//get back to //wsdl:definitions/wsp:Policy
+            String policy = checkPolicyIntegrated(xPath, nodeList.item(i).getParentNode().getParentNode().getParentNode());
+            policies.put("#" + policy, new BindingPolicy("#" + policy));
+        }
+        return policies;
+    }
 
     private static String checkPolicy(XPath xPath, Node node)
             throws XPathExpressionException {
@@ -304,6 +373,13 @@ class MexParser {
             log.debug("potential policy did not match required transport binding: "
                     + nodeValue);
         }
+        return policyId;
+    }
+    
+    private static String checkPolicyIntegrated(XPath xPath, Node node)
+            throws XPathExpressionException {
+        Node id = node.getAttributes().getNamedItem("wsu:Id");
+        String policyId = id.getNodeValue();
         return policyId;
     }
 }

--- a/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
@@ -77,26 +77,20 @@ class WSTrustRequest {
         return WSTrustResponse.parse(response, policy.getVersion());
     }
     
-    static WSTrustResponse execute(String mexURL, String cloudAudienceUrn, Proxy proxy, SSLSocketFactory sslSocketFactory)
-            throws Exception {
+    static WSTrustResponse execute(String mexURL,
+            String cloudAudienceUrn,
+            Proxy proxy,
+            SSLSocketFactory sslSocketFactory) throws Exception {
 
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Content-Type", "application/soap+xml");
         headers.put("return-client-request-id", "true");
-        
-        // Discover the policy for authentication using the Metadata Exchange Url. 
-        String mexResponse = HttpHelper.executeHttpGet(log, mexURL,
-                proxy, sslSocketFactory);
-        
-        System.out.println("mexResponse: " + mexResponse);
-        
-        
+
+        // Discover the policy for authentication using the Metadata Exchange Url.
+        String mexResponse = HttpHelper.executeHttpGet(log, mexURL, proxy, sslSocketFactory);
+
         BindingPolicy policy = MexParser.getPolicyFromMexResponseForIntegrated(mexResponse);
-        System.out.println("policy.getVersion(): " + policy.getVersion());
-        System.out.println("policy.getUrl(): " + policy.getUrl());
-        
-        
-        
+
         String soapAction = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"; // default
                                                                                           // value
                                                                                           // (WSTrust
@@ -111,128 +105,24 @@ class WSTrustRequest {
         }
 
         headers.put("SOAPAction", soapAction);
-        headers.put("return-client-request-id", "true");
-        
-        
-        
-        
-        String body = buildMessage(policy.getUrl(),
-                policy.getVersion(), cloudAudienceUrn).toString();
-        
-        
-        System.out.println("headers: " + headers);
-        System.out.println("body: " + body);
-        
-        System.out.println("before WSTrust Token response");
-        
-        //Get the WSTrust Token (Web Service Trust Token)
-        String response = HttpHelper.executeHttpPost(log, policy.getUrl(),
-                body, headers, proxy, sslSocketFactory);
-        
-        System.out.println("after WSTrust Token response");
-        
+
+        String body = buildMessage(policy.getUrl(), null, null, policy.getVersion(), cloudAudienceUrn).toString();
+
+        // Get the WSTrust Token (Web Service Trust Token)
+        String response = HttpHelper.executeHttpPost(log, policy.getUrl(), body, headers, proxy, sslSocketFactory);
+
         return WSTrustResponse.parse(response, policy.getVersion());
-    }
-    
-    static StringBuilder buildMessage(String address, WSTrustVersion addressVersion, String cloudAudienceUrn) {
-
-//        StringBuilder securityHeaderBuilder = new StringBuilder(
-//                MAX_EXPECTED_MESSAGE_SIZE);
-//        buildSecurityHeader(securityHeaderBuilder, username, password,
-//                addressVersion);
-        String guid = UUID.randomUUID().toString();
-        StringBuilder messageBuilder = new StringBuilder(
-                MAX_EXPECTED_MESSAGE_SIZE);
-
-        String schemaLocation = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
-        String soapAction = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue";
-        String rstTrustNamespace = "http://docs.oasis-open.org/ws-sx/ws-trust/200512";
-        String keyType = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer";
-        String requestType = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/Issue";
-
-        if (addressVersion == WSTrustVersion.WSTRUST2005) {
-            soapAction = "http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue";
-            rstTrustNamespace = "http://schemas.xmlsoap.org/ws/2005/02/trust";
-            keyType = "http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey";
-            requestType = "http://schemas.xmlsoap.org/ws/2005/02/trust/Issue";
-        }
-
-        // Example WSTrust 1.3 request
-        // <s:Envelope xmlns:wst='http://schemas.xmlsoap.org/ws/2005/02/trust'
-        // xmlns:wssc='http://schemas.xmlsoap.org/ws/2005/02/sc'
-        // xmlns:wsa='http://www.w3.org/2005/08/addressing'
-        // xmlns:wsu='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd'
-        // xmlns:wsp='http://schemas.xmlsoap.org/ws/2004/09/policy'
-        // xmlns:saml='urn:oasis:names:tc:SAML:1.0:assertion'
-        // xmlns:wsse='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'
-        // xmlns:ps='http://schemas.microsoft.com/Passport/SoapServices/PPCRL'
-        // mlns:s='http://www.w3.org/2003/05/soap-envelope'>
-        // <s:Header>
-        // <wsa:Action
-        // s:mustUnderstand='1'>http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue</wsa:Action>
-        // <wsa:To
-        // s:mustUnderstand='1'>https://corp.sts.microsoft.com:443/adfs/services/trust/2005/windowstransport</wsa:To>
-        // <wsa:MessageID>1303795308</wsa:MessageID>-<wsse:Security>-<wsu:Timestamp
-        // Id="Timestamp"><wsu:Created>2011-04-26T05:21:50Z</wsu:Created><wsu:Expires>2011-04-26T05:26:50Z</wsu:Expires></wsu:Timestamp></wsse:Security></s:Header>-<s:Body>-<wst:RequestSecurityToken
-        // Id="RST0"><wst:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</wst:RequestType>-<wsp:AppliesTo>-<wsa:EndpointReference><wsa:Address>urn:federation:MicrosoftOnline</wsa:Address></wsa:EndpointReference></wsp:AppliesTo><wst:KeyType>http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey</wst:KeyType></wst:RequestSecurityToken></s:Body></s:Envelope>
-        messageBuilder
-                .append(String
-                        .format("<s:Envelope xmlns:s='http://www.w3.org/2003/05/soap-envelope' xmlns:a='http://www.w3.org/2005/08/addressing' xmlns:u='%s'>"
-                                + "<s:Header>"
-                                + "<a:Action s:mustUnderstand='1'>%s</a:Action>"
-                                + "<a:messageID>urn:uuid:"
-                                + "%s"
-                                + // guid
-                                "</a:messageID>"
-                                + "<a:ReplyTo>"
-                                + "<a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address>"
-                                + "</a:ReplyTo>"
-                                + "<a:To s:mustUnderstand='1'>"
-                                + "%s"
-                                + // resource
-                                "</a:To>"
-//                                + "%s"
-                                + // securityHeader
-                                "</s:Header>"
-                                + "<s:Body>"
-                                + "<trust:RequestSecurityToken xmlns:trust='%s'>"
-                                + "<wsp:AppliesTo xmlns:wsp='http://schemas.xmlsoap.org/ws/2004/09/policy'>"
-                                + "<a:EndpointReference>"
-                                + "<a:Address>"
-                                + "%s"
-                                + // appliesTo like
-                                  // urn:federation:MicrosoftOnline. Either
-                                  // wst:TokenType or wst:AppliesTo should be
-                                  // defined in the token request message. If
-                                  // both are specified, the wst:AppliesTo field
-                                  // takes precedence.
-                                "</a:Address>"
-                                + "</a:EndpointReference>"
-                                + "</wsp:AppliesTo>"
-                                + "<trust:KeyType>%s</trust:KeyType>"
-                                + "<trust:RequestType>%s</trust:RequestType>"
-                                + // If we dont specify tokentype, it will
-                                  // return samlv1.1
-                                "</trust:RequestSecurityToken>"
-                                + "</s:Body>"
-                                + "</s:Envelope>", schemaLocation, soapAction,
-                                guid, address,
-//                                securityHeaderBuilder.toString(),
-                                rstTrustNamespace,
-                                StringUtils.isNotEmpty(cloudAudienceUrn) ? cloudAudienceUrn : DEFAULT_APPLIES_TO,
-                                keyType,
-                                requestType));
-
-        return messageBuilder;
     }
 
     static StringBuilder buildMessage(String address, String username,
             String password, WSTrustVersion addressVersion, String cloudAudienceUrn) {
+        boolean integrated = (username == null) & (password == null);
 
-        StringBuilder securityHeaderBuilder = new StringBuilder(
-                MAX_EXPECTED_MESSAGE_SIZE);
-        buildSecurityHeader(securityHeaderBuilder, username, password,
-                addressVersion);
+        StringBuilder securityHeaderBuilder = new StringBuilder(MAX_EXPECTED_MESSAGE_SIZE);
+        if (!integrated) {
+            buildSecurityHeader(securityHeaderBuilder, username, password, addressVersion);
+        }
+        
         String guid = UUID.randomUUID().toString();
         StringBuilder messageBuilder = new StringBuilder(
                 MAX_EXPECTED_MESSAGE_SIZE);
@@ -310,7 +200,7 @@ class WSTrustRequest {
                                 + "</s:Body>"
                                 + "</s:Envelope>", schemaLocation, soapAction,
                                 guid, address,
-                                securityHeaderBuilder.toString(),
+                                integrated ? "" : securityHeaderBuilder.toString(),
                                 rstTrustNamespace,
                                 StringUtils.isNotEmpty(cloudAudienceUrn) ? cloudAudienceUrn : DEFAULT_APPLIES_TO,
                                 keyType,

--- a/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
@@ -76,7 +76,7 @@ class WSTrustRequest {
                 body, headers, proxy, sslSocketFactory);
         return WSTrustResponse.parse(response, policy.getVersion());
     }
-    
+
     static WSTrustResponse execute(String mexURL,
             String cloudAudienceUrn,
             Proxy proxy,
@@ -122,7 +122,7 @@ class WSTrustRequest {
         if (!integrated) {
             buildSecurityHeader(securityHeaderBuilder, username, password, addressVersion);
         }
-        
+
         String guid = UUID.randomUUID().toString();
         StringBuilder messageBuilder = new StringBuilder(
                 MAX_EXPECTED_MESSAGE_SIZE);

--- a/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
@@ -76,6 +76,151 @@ class WSTrustRequest {
                 body, headers, proxy, sslSocketFactory);
         return WSTrustResponse.parse(response, policy.getVersion());
     }
+    
+    static WSTrustResponse execute(String url, String cloudAudienceUrn, Proxy proxy, SSLSocketFactory sslSocketFactory)
+            throws Exception {
+
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Content-Type", "application/soap+xml");
+        headers.put("return-client-request-id", "true");
+        
+        
+        String mexResponse = HttpHelper.executeHttpGet(log, url,
+                proxy, sslSocketFactory);
+        
+
+        //TODO : need to parse mexResponse to get the  following URL and version
+        //Parsing details for the metadata XML
+        BindingPolicy policy = new BindingPolicy("https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport", WSTrustVersion.WSTRUST13);
+        
+        System.out.println("policy.getVersion(): " + policy.getVersion());
+        System.out.println("policy.getUrl(): " + policy.getUrl());
+        
+        
+        
+        String soapAction = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"; // default
+                                                                                          // value
+                                                                                          // (WSTrust
+                                                                                          // 1.3)
+
+        // only change it if version is wsTrust2005, otherwise default to
+        // wsTrust13
+        if (policy.getVersion() == WSTrustVersion.WSTRUST2005) {
+            soapAction = "http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue"; // wsTrust2005
+                                                                                  // soap
+                                                                                  // value
+        }
+
+        headers.put("SOAPAction", soapAction);
+        headers.put("return-client-request-id", "true");
+        
+        
+        
+        
+        String body = buildMessage(policy.getUrl(),
+                policy.getVersion(), cloudAudienceUrn).toString();
+        
+        
+        System.out.println("headers: " + headers);
+        System.out.println("body: " + body);
+        
+        
+        String response = HttpHelper.executeHttpPost(log, policy.getUrl(),
+                body, headers, proxy, sslSocketFactory);
+        return WSTrustResponse.parse(response, policy.getVersion());
+    }
+    
+    static StringBuilder buildMessage(String address, WSTrustVersion addressVersion, String cloudAudienceUrn) {
+
+//        StringBuilder securityHeaderBuilder = new StringBuilder(
+//                MAX_EXPECTED_MESSAGE_SIZE);
+//        buildSecurityHeader(securityHeaderBuilder, username, password,
+//                addressVersion);
+        String guid = UUID.randomUUID().toString();
+        StringBuilder messageBuilder = new StringBuilder(
+                MAX_EXPECTED_MESSAGE_SIZE);
+
+        String schemaLocation = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
+        String soapAction = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue";
+        String rstTrustNamespace = "http://docs.oasis-open.org/ws-sx/ws-trust/200512";
+        String keyType = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer";
+        String requestType = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/Issue";
+
+        if (addressVersion == WSTrustVersion.WSTRUST2005) {
+            soapAction = "http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue";
+            rstTrustNamespace = "http://schemas.xmlsoap.org/ws/2005/02/trust";
+            keyType = "http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey";
+            requestType = "http://schemas.xmlsoap.org/ws/2005/02/trust/Issue";
+        }
+
+        // Example WSTrust 1.3 request
+        // <s:Envelope xmlns:wst='http://schemas.xmlsoap.org/ws/2005/02/trust'
+        // xmlns:wssc='http://schemas.xmlsoap.org/ws/2005/02/sc'
+        // xmlns:wsa='http://www.w3.org/2005/08/addressing'
+        // xmlns:wsu='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd'
+        // xmlns:wsp='http://schemas.xmlsoap.org/ws/2004/09/policy'
+        // xmlns:saml='urn:oasis:names:tc:SAML:1.0:assertion'
+        // xmlns:wsse='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'
+        // xmlns:ps='http://schemas.microsoft.com/Passport/SoapServices/PPCRL'
+        // mlns:s='http://www.w3.org/2003/05/soap-envelope'>
+        // <s:Header>
+        // <wsa:Action
+        // s:mustUnderstand='1'>http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue</wsa:Action>
+        // <wsa:To
+        // s:mustUnderstand='1'>https://corp.sts.microsoft.com:443/adfs/services/trust/2005/windowstransport</wsa:To>
+        // <wsa:MessageID>1303795308</wsa:MessageID>-<wsse:Security>-<wsu:Timestamp
+        // Id="Timestamp"><wsu:Created>2011-04-26T05:21:50Z</wsu:Created><wsu:Expires>2011-04-26T05:26:50Z</wsu:Expires></wsu:Timestamp></wsse:Security></s:Header>-<s:Body>-<wst:RequestSecurityToken
+        // Id="RST0"><wst:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</wst:RequestType>-<wsp:AppliesTo>-<wsa:EndpointReference><wsa:Address>urn:federation:MicrosoftOnline</wsa:Address></wsa:EndpointReference></wsp:AppliesTo><wst:KeyType>http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey</wst:KeyType></wst:RequestSecurityToken></s:Body></s:Envelope>
+        messageBuilder
+                .append(String
+                        .format("<s:Envelope xmlns:s='http://www.w3.org/2003/05/soap-envelope' xmlns:a='http://www.w3.org/2005/08/addressing' xmlns:u='%s'>"
+                                + "<s:Header>"
+                                + "<a:Action s:mustUnderstand='1'>%s</a:Action>"
+                                + "<a:messageID>urn:uuid:"
+                                + "%s"
+                                + // guid
+                                "</a:messageID>"
+                                + "<a:ReplyTo>"
+                                + "<a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address>"
+                                + "</a:ReplyTo>"
+                                + "<a:To s:mustUnderstand='1'>"
+                                + "%s"
+                                + // resource
+                                "</a:To>"
+//                                + "%s"
+                                + // securityHeader
+                                "</s:Header>"
+                                + "<s:Body>"
+                                + "<trust:RequestSecurityToken xmlns:trust='%s'>"
+                                + "<wsp:AppliesTo xmlns:wsp='http://schemas.xmlsoap.org/ws/2004/09/policy'>"
+                                + "<a:EndpointReference>"
+                                + "<a:Address>"
+                                + "%s"
+                                + // appliesTo like
+                                  // urn:federation:MicrosoftOnline. Either
+                                  // wst:TokenType or wst:AppliesTo should be
+                                  // defined in the token request message. If
+                                  // both are specified, the wst:AppliesTo field
+                                  // takes precedence.
+                                "</a:Address>"
+                                + "</a:EndpointReference>"
+                                + "</wsp:AppliesTo>"
+                                + "<trust:KeyType>%s</trust:KeyType>"
+                                + "<trust:RequestType>%s</trust:RequestType>"
+                                + // If we dont specify tokentype, it will
+                                  // return samlv1.1
+                                "</trust:RequestSecurityToken>"
+                                + "</s:Body>"
+                                + "</s:Envelope>", schemaLocation, soapAction,
+                                guid, address,
+//                                securityHeaderBuilder.toString(),
+                                rstTrustNamespace,
+                                StringUtils.isNotEmpty(cloudAudienceUrn) ? cloudAudienceUrn : DEFAULT_APPLIES_TO,
+                                keyType,
+                                requestType));
+
+        return messageBuilder;
+    }
 
     static StringBuilder buildMessage(String address, String username,
             String password, WSTrustVersion addressVersion, String cloudAudienceUrn) {

--- a/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
@@ -123,9 +123,14 @@ class WSTrustRequest {
         System.out.println("headers: " + headers);
         System.out.println("body: " + body);
         
+        System.out.println("before WSTrust Token response");
+        
         //Get the WSTrust Token (Web Service Trust Token)
         String response = HttpHelper.executeHttpPost(log, policy.getUrl(),
                 body, headers, proxy, sslSocketFactory);
+        
+        System.out.println("after WSTrust Token response");
+        
         return WSTrustResponse.parse(response, policy.getVersion());
     }
     

--- a/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
@@ -84,7 +84,7 @@ class WSTrustRequest {
         headers.put("Content-Type", "application/soap+xml");
         headers.put("return-client-request-id", "true");
         
-        
+        // Discover the policy for authentication using the Metadata Exchange Url. 
         String mexResponse = HttpHelper.executeHttpGet(log, url,
                 proxy, sslSocketFactory);
         
@@ -130,12 +130,9 @@ class WSTrustRequest {
         System.out.println("headers: " + headers);
         System.out.println("body: " + body);
         
-        
+        //Get the WSTrust Token (Web Service Trust Token)
         String response = HttpHelper.executeHttpPost(log, policy.getUrl(),
                 body, headers, proxy, sslSocketFactory);
-        
-        System.out.println("response: " + response);
-        
         return WSTrustResponse.parse(response, policy.getVersion());
     }
     

--- a/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
@@ -77,7 +77,7 @@ class WSTrustRequest {
         return WSTrustResponse.parse(response, policy.getVersion());
     }
     
-    static WSTrustResponse execute(String url, String cloudAudienceUrn, Proxy proxy, SSLSocketFactory sslSocketFactory)
+    static WSTrustResponse execute(String mexURL, String cloudAudienceUrn, Proxy proxy, SSLSocketFactory sslSocketFactory)
             throws Exception {
 
         Map<String, String> headers = new HashMap<String, String>();
@@ -85,10 +85,19 @@ class WSTrustRequest {
         headers.put("return-client-request-id", "true");
         
         // Discover the policy for authentication using the Metadata Exchange Url. 
-        String mexResponse = HttpHelper.executeHttpGet(log, url,
+        String mexResponse = HttpHelper.executeHttpGet(log, mexURL,
                 proxy, sslSocketFactory);
         
         System.out.println("mexResponse: " + mexResponse);
+        
+        
+        BindingPolicy tempPolicy = MexParser.getWsTrustEndpointFromMexResponse(mexResponse);
+        System.out.println("!!!!!!!!!!!!!tempPolicy.getUrl(): " + tempPolicy.getUrl());
+        System.out.println("!!!!!!!!!!!!!tempPolicy.getVersion(): " + tempPolicy.getVersion());
+        System.out.println("!!!!!!!!!!!!!tempPolicy.getValue(): " + tempPolicy.getValue());
+        
+        
+        
         
         String policyURL = "https://msft.sts.microsoft.com/adfs/services/trust/13/usernamemixed";
         if(mexResponse.contains("https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport")) {

--- a/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
@@ -88,10 +88,16 @@ class WSTrustRequest {
         String mexResponse = HttpHelper.executeHttpGet(log, url,
                 proxy, sslSocketFactory);
         
+        System.out.println("mexResponse: " + mexResponse);
+        
+        String policyURL = "https://msft.sts.microsoft.com/adfs/services/trust/13/usernamemixed";
+        if(mexResponse.contains("https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport")) {
+        	policyURL = "https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport";
+        }
 
         //TODO : need to parse mexResponse to get the  following URL and version
         //Parsing details for the metadata XML
-        BindingPolicy policy = new BindingPolicy("https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport", WSTrustVersion.WSTRUST13);
+        BindingPolicy policy = new BindingPolicy(policyURL, WSTrustVersion.WSTRUST13);
         
         System.out.println("policy.getVersion(): " + policy.getVersion());
         System.out.println("policy.getUrl(): " + policy.getUrl());
@@ -127,6 +133,9 @@ class WSTrustRequest {
         
         String response = HttpHelper.executeHttpPost(log, policy.getUrl(),
                 body, headers, proxy, sslSocketFactory);
+        
+        System.out.println("response: " + response);
+        
         return WSTrustResponse.parse(response, policy.getVersion());
     }
     

--- a/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/WSTrustRequest.java
@@ -91,23 +91,7 @@ class WSTrustRequest {
         System.out.println("mexResponse: " + mexResponse);
         
         
-        BindingPolicy tempPolicy = MexParser.getWsTrustEndpointFromMexResponse(mexResponse);
-        System.out.println("!!!!!!!!!!!!!tempPolicy.getUrl(): " + tempPolicy.getUrl());
-        System.out.println("!!!!!!!!!!!!!tempPolicy.getVersion(): " + tempPolicy.getVersion());
-        System.out.println("!!!!!!!!!!!!!tempPolicy.getValue(): " + tempPolicy.getValue());
-        
-        
-        
-        
-        String policyURL = "https://msft.sts.microsoft.com/adfs/services/trust/13/usernamemixed";
-        if(mexResponse.contains("https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport")) {
-        	policyURL = "https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport";
-        }
-
-        //TODO : need to parse mexResponse to get the  following URL and version
-        //Parsing details for the metadata XML
-        BindingPolicy policy = new BindingPolicy(policyURL, WSTrustVersion.WSTRUST13);
-        
+        BindingPolicy policy = MexParser.getPolicyFromMexResponseForIntegrated(mexResponse);
         System.out.println("policy.getVersion(): " + policy.getVersion());
         System.out.println("policy.getUrl(): " + policy.getUrl());
         

--- a/src/test/java/com/microsoft/aad/adal4j/MexParserTest.java
+++ b/src/test/java/com/microsoft/aad/adal4j/MexParserTest.java
@@ -85,4 +85,24 @@ public class MexParserTest {
         Assert.assertEquals(endpoint.getUrl(),"https://msft.sts.microsoft.com/adfs/services/trust/2005/usernamemixed");
     }
 
+    @Test
+    public void testMexParsingIntegrated() throws Exception {
+
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader br = new BufferedReader(new FileReader(
+                (this.getClass().getResource(
+                        TestConfiguration.AAD_MEX_RESPONSE_FILE_INTEGRATED).getFile())))) {
+            String line = br.readLine();
+
+            while (line != null) {
+                sb.append(line);
+                sb.append(System.lineSeparator());
+                line = br.readLine();
+            }
+        }
+        BindingPolicy endpoint = MexParser.getPolicyFromMexResponseForIntegrated(sb
+                .toString());
+        Assert.assertEquals(endpoint.getUrl(),
+                "https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport");
+    }
 }

--- a/src/test/java/com/microsoft/aad/adal4j/TestConfiguration.java
+++ b/src/test/java/com/microsoft/aad/adal4j/TestConfiguration.java
@@ -34,6 +34,7 @@ public final class TestConfiguration {
     public final static String AAD_RESOURCE_ID = "b7a671d8-a408-42ff-86e0-aaf447fd17c4";
     public final static String AAD_CERTIFICATE_PATH = "/test-certificate.pfx";
     public final static String AAD_MEX_RESPONSE_FILE = "/mex-response.xml";
+    public final static String AAD_MEX_RESPONSE_FILE_INTEGRATED = "/mex-response-integrated.xml";
     public final static String AAD_MEX_2005_RESPONSE_FILE = "/mex-2005-response.xml";
     public final static String AAD_TOKEN_ERROR_FILE = "/token-error.xml";
     public final static String AAD_TOKEN_SUCCESS_FILE = "/token.xml";

--- a/src/test/java/com/microsoft/aad/adal4j/WSTrustRequestTest.java
+++ b/src/test/java/com/microsoft/aad/adal4j/WSTrustRequestTest.java
@@ -52,4 +52,13 @@ public class WSTrustRequestTest {
 
         Assert.assertTrue(msg.contains("<a:EndpointReference><a:Address>" + WSTrustRequest.DEFAULT_APPLIES_TO + "</a:Address></a:EndpointReference>"));
     }
+    
+    @Test
+    public void buildMessage_integrated() throws Exception {
+        String msg = WSTrustRequest.buildMessage("address", null,
+                null, WSTrustVersion.WSTRUST13, "cloudAudienceUrn").toString();
+
+        Assert.assertTrue(msg.contains("<a:EndpointReference><a:Address>cloudAudienceUrn</a:Address></a:EndpointReference>"));
+        Assert.assertTrue(!msg.contains("<o:Security s:mustUnderstand"));
+    }
 }

--- a/src/test/resources/mex-response-integrated.xml
+++ b/src/test/resources/mex-response-integrated.xml
@@ -1,0 +1,779 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SecurityTokenService" targetNamespace="http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:t="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:trust="http://docs.oasis-open.org/ws-sx/ws-trust/200512" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+	<wsp:Policy wsu:Id="CustomBinding_IWSTrustFeb2005Async_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<msis:DomainInternet xmlns:msis="http://schemas.microsoft.com/ws/2009/12/identityserver/"/>
+				<http:NegotiateAuthentication xmlns:http="http://schemas.microsoft.com/ws/06/2004/policy/http"/>
+				<sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="false"/>
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256/>
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict/>
+							</wsp:Policy>
+						</sp:Layout>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<wsaw:UsingAddressing/>
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="CertificateWSTrustBinding_IWSTrustFeb2005Async_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="false"/>
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256/>
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict/>
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp/>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+							<wsp:Policy>
+								<sp:RequireThumbprintReference/>
+								<sp:WssX509V3Token10/>
+							</wsp:Policy>
+						</sp:X509Token>
+						<mssp:RsaToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true" xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy"/>
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:MustSupportRefThumbprint/>
+					</wsp:Policy>
+				</sp:Wss11>
+				<sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens/>
+						<sp:RequireClientEntropy/>
+						<sp:RequireServerEntropy/>
+					</wsp:Policy>
+				</sp:Trust10>
+				<wsaw:UsingAddressing/>
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="CertificateWSTrustBinding_IWSTrustFeb2005Async1_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="true"/>
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256/>
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict/>
+							</wsp:Policy>
+						</sp:Layout>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<wsaw:UsingAddressing/>
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="UserNameWSTrustBinding_IWSTrustFeb2005Async_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="false"/>
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256/>
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict/>
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp/>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:SignedSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+							<wsp:Policy>
+								<sp:WssUsernameToken10/>
+							</wsp:Policy>
+						</sp:UsernameToken>
+					</wsp:Policy>
+				</sp:SignedSupportingTokens>
+				<sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<mssp:RsaToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true" xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy"/>
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy/>
+				</sp:Wss11>
+				<sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens/>
+						<sp:RequireClientEntropy/>
+						<sp:RequireServerEntropy/>
+					</wsp:Policy>
+				</sp:Trust10>
+				<wsaw:UsingAddressing/>
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="false"/>
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256/>
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict/>
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp/>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:IssuedToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+							<sp:RequestSecurityTokenTemplate>
+								<t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/PublicKey</t:KeyType>
+								<t:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</t:EncryptWith>
+								<t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</t:SignatureAlgorithm>
+								<t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>
+								<t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>
+							</sp:RequestSecurityTokenTemplate>
+							<wsp:Policy>
+								<sp:RequireInternalReference/>
+							</wsp:Policy>
+						</sp:IssuedToken>
+						<mssp:RsaToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true" xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy"/>
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy/>
+				</sp:Wss11>
+				<sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens/>
+						<sp:RequireClientEntropy/>
+						<sp:RequireServerEntropy/>
+					</wsp:Policy>
+				</sp:Trust10>
+				<wsaw:UsingAddressing/>
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="false"/>
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256/>
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict/>
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp/>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:IssuedToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+							<sp:RequestSecurityTokenTemplate>
+								<t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/SymmetricKey</t:KeyType>
+								<t:KeySize>256</t:KeySize>
+								<t:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptWith>
+								<t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</t:SignatureAlgorithm>
+								<t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>
+								<t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>
+							</sp:RequestSecurityTokenTemplate>
+							<wsp:Policy>
+								<sp:RequireInternalReference/>
+							</wsp:Policy>
+						</sp:IssuedToken>
+						<mssp:RsaToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true" xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy"/>
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy/>
+				</sp:Wss11>
+				<sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens/>
+						<sp:RequireClientEntropy/>
+						<sp:RequireServerEntropy/>
+					</wsp:Policy>
+				</sp:Trust10>
+				<wsaw:UsingAddressing/>
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="CertificateWSTrustBinding_IWSTrust13Async_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken/>
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256/>
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict/>
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp/>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:EndorsingSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:X509Token sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+							<wsp:Policy>
+								<sp:RequireThumbprintReference/>
+								<sp:WssX509V3Token10/>
+							</wsp:Policy>
+						</sp:X509Token>
+						<sp:KeyValueToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never" wsp:Optional="true"/>
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:MustSupportRefThumbprint/>
+					</wsp:Policy>
+				</sp:Wss11>
+				<sp:Trust13 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens/>
+						<sp:RequireClientEntropy/>
+						<sp:RequireServerEntropy/>
+					</wsp:Policy>
+				</sp:Trust13>
+				<wsaw:UsingAddressing/>
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="UserNameWSTrustBinding_IWSTrust13Async_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken/>
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256/>
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict/>
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp/>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:SignedEncryptedSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:UsernameToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+							<wsp:Policy>
+								<sp:WssUsernameToken10/>
+							</wsp:Policy>
+						</sp:UsernameToken>
+					</wsp:Policy>
+				</sp:SignedEncryptedSupportingTokens>
+				<sp:EndorsingSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:KeyValueToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never" wsp:Optional="true"/>
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy/>
+				</sp:Wss11>
+				<sp:Trust13 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens/>
+						<sp:RequireClientEntropy/>
+						<sp:RequireServerEntropy/>
+					</wsp:Policy>
+				</sp:Trust13>
+				<wsaw:UsingAddressing/>
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrust13Async_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken/>
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256/>
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict/>
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp/>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:EndorsingSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:IssuedToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+							<sp:RequestSecurityTokenTemplate>
+								<trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/PublicKey</trust:KeyType>
+								<trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>
+								<trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:EncryptWith>
+								<trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</trust:SignatureAlgorithm>
+								<trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>
+								<trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>
+							</sp:RequestSecurityTokenTemplate>
+							<wsp:Policy>
+								<sp:RequireInternalReference/>
+							</wsp:Policy>
+						</sp:IssuedToken>
+						<sp:KeyValueToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never" wsp:Optional="true"/>
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy/>
+				</sp:Wss11>
+				<sp:Trust13 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens/>
+						<sp:RequireClientEntropy/>
+						<sp:RequireServerEntropy/>
+					</wsp:Policy>
+				</sp:Trust13>
+				<wsaw:UsingAddressing/>
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrust13Async1_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<sp:TransportBinding xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken/>
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256/>
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict/>
+							</wsp:Policy>
+						</sp:Layout>
+						<sp:IncludeTimestamp/>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<sp:EndorsingSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:IssuedToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+							<sp:RequestSecurityTokenTemplate>
+								<trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/SymmetricKey</trust:KeyType>
+								<trust:KeySize>256</trust:KeySize>
+								<trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>
+								<trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptWith>
+								<trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</trust:SignatureAlgorithm>
+								<trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>
+								<trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>
+							</sp:RequestSecurityTokenTemplate>
+							<wsp:Policy>
+								<sp:RequireInternalReference/>
+							</wsp:Policy>
+						</sp:IssuedToken>
+						<sp:KeyValueToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never" wsp:Optional="true"/>
+						<sp:SignedParts>
+							<sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+						</sp:SignedParts>
+					</wsp:Policy>
+				</sp:EndorsingSupportingTokens>
+				<sp:Wss11 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy/>
+				</sp:Wss11>
+				<sp:Trust13 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+					<wsp:Policy>
+						<sp:MustSupportIssuedTokens/>
+						<sp:RequireClientEntropy/>
+						<sp:RequireServerEntropy/>
+					</wsp:Policy>
+				</sp:Trust13>
+				<wsaw:UsingAddressing/>
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="CustomBinding_IWSTrust13Async_policy">
+		<wsp:ExactlyOne>
+			<wsp:All>
+				<msis:DomainInternet xmlns:msis="http://schemas.microsoft.com/ws/2009/12/identityserver/"/>
+				<http:NegotiateAuthentication xmlns:http="http://schemas.microsoft.com/ws/06/2004/policy/http"/>
+				<sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+					<wsp:Policy>
+						<sp:TransportToken>
+							<wsp:Policy>
+								<sp:HttpsToken RequireClientCertificate="false"/>
+							</wsp:Policy>
+						</sp:TransportToken>
+						<sp:AlgorithmSuite>
+							<wsp:Policy>
+								<sp:Basic256/>
+							</wsp:Policy>
+						</sp:AlgorithmSuite>
+						<sp:Layout>
+							<wsp:Policy>
+								<sp:Strict/>
+							</wsp:Policy>
+						</sp:Layout>
+					</wsp:Policy>
+				</sp:TransportBinding>
+				<wsaw:UsingAddressing/>
+			</wsp:All>
+		</wsp:ExactlyOne>
+	</wsp:Policy>
+	<wsdl:types>
+		<xsd:schema targetNamespace="http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice/Imports">
+			<xsd:import schemaLocation="https://msft.sts.microsoft.com/adfs/services/trust/mex?xsd=xsd0" namespace="http://schemas.microsoft.com/Message"/>
+			<xsd:import schemaLocation="https://msft.sts.microsoft.com/adfs/services/trust/mex?xsd=xsd1" namespace="http://schemas.xmlsoap.org/ws/2005/02/trust"/>
+			<xsd:import schemaLocation="https://msft.sts.microsoft.com/adfs/services/trust/mex?xsd=xsd2" namespace="http://docs.oasis-open.org/ws-sx/ws-trust/200512"/>
+		</xsd:schema>
+	</wsdl:types>
+	<wsdl:message name="IWSTrustFeb2005Async_TrustFeb2005IssueAsync_InputMessage">
+		<wsdl:part name="request" element="t:RequestSecurityToken"/>
+	</wsdl:message>
+	<wsdl:message name="IWSTrustFeb2005Async_TrustFeb2005IssueAsync_OutputMessage">
+		<wsdl:part name="TrustFeb2005IssueAsyncResult" element="t:RequestSecurityTokenResponse"/>
+	</wsdl:message>
+	<wsdl:message name="IWSTrust13Async_Trust13IssueAsync_InputMessage">
+		<wsdl:part name="request" element="trust:RequestSecurityToken"/>
+	</wsdl:message>
+	<wsdl:message name="IWSTrust13Async_Trust13IssueAsync_OutputMessage">
+		<wsdl:part name="Trust13IssueAsyncResult" element="trust:RequestSecurityTokenResponseCollection"/>
+	</wsdl:message>
+	<wsdl:portType name="IWSTrustFeb2005Async">
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<wsdl:input wsaw:Action="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" message="tns:IWSTrustFeb2005Async_TrustFeb2005IssueAsync_InputMessage"/>
+			<wsdl:output wsaw:Action="http://schemas.xmlsoap.org/ws/2005/02/trust/RSTR/Issue" message="tns:IWSTrustFeb2005Async_TrustFeb2005IssueAsync_OutputMessage"/>
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:portType name="IWSTrust13Async">
+		<wsdl:operation name="Trust13IssueAsync">
+			<wsdl:input wsaw:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" message="tns:IWSTrust13Async_Trust13IssueAsync_InputMessage"/>
+			<wsdl:output wsaw:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTRC/IssueFinal" message="tns:IWSTrust13Async_Trust13IssueAsync_OutputMessage"/>
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="CustomBinding_IWSTrustFeb2005Async" type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference URI="#CustomBinding_IWSTrustFeb2005Async_policy"/>
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+			<wsdl:input>
+				<soap12:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="CertificateWSTrustBinding_IWSTrustFeb2005Async" type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference URI="#CertificateWSTrustBinding_IWSTrustFeb2005Async_policy"/>
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+			<wsdl:input>
+				<soap12:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="CertificateWSTrustBinding_IWSTrustFeb2005Async1" type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference URI="#CertificateWSTrustBinding_IWSTrustFeb2005Async1_policy"/>
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+			<wsdl:input>
+				<soap12:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="UserNameWSTrustBinding_IWSTrustFeb2005Async" type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference URI="#UserNameWSTrustBinding_IWSTrustFeb2005Async_policy"/>
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+			<wsdl:input>
+				<soap12:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async" type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference URI="#IssuedTokenWSTrustBinding_IWSTrustFeb2005Async_policy"/>
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+			<wsdl:input>
+				<soap12:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1" type="tns:IWSTrustFeb2005Async">
+		<wsp:PolicyReference URI="#IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1_policy"/>
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="TrustFeb2005IssueAsync">
+			<soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+			<wsdl:input>
+				<soap12:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="CertificateWSTrustBinding_IWSTrust13Async" type="tns:IWSTrust13Async">
+		<wsp:PolicyReference URI="#CertificateWSTrustBinding_IWSTrust13Async_policy"/>
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Trust13IssueAsync">
+			<soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document"/>
+			<wsdl:input>
+				<soap12:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="UserNameWSTrustBinding_IWSTrust13Async" type="tns:IWSTrust13Async">
+		<wsp:PolicyReference URI="#UserNameWSTrustBinding_IWSTrust13Async_policy"/>
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Trust13IssueAsync">
+			<soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document"/>
+			<wsdl:input>
+				<soap12:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrust13Async" type="tns:IWSTrust13Async">
+		<wsp:PolicyReference URI="#IssuedTokenWSTrustBinding_IWSTrust13Async_policy"/>
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Trust13IssueAsync">
+			<soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document"/>
+			<wsdl:input>
+				<soap12:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrust13Async1" type="tns:IWSTrust13Async">
+		<wsp:PolicyReference URI="#IssuedTokenWSTrustBinding_IWSTrust13Async1_policy"/>
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Trust13IssueAsync">
+			<soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document"/>
+			<wsdl:input>
+				<soap12:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:binding name="CustomBinding_IWSTrust13Async" type="tns:IWSTrust13Async">
+		<wsp:PolicyReference URI="#CustomBinding_IWSTrust13Async_policy"/>
+		<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Trust13IssueAsync">
+			<soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document"/>
+			<wsdl:input>
+				<soap12:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap12:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="SecurityTokenService">
+		<wsdl:port name="CustomBinding_IWSTrustFeb2005Async" binding="tns:CustomBinding_IWSTrustFeb2005Async">
+			<soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/2005/windowstransport"/>
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/windowstransport</wsa10:Address>
+				<Identity xmlns="http://schemas.xmlsoap.org/ws/2006/02/addressingidentity">
+					<Spn>HOST/adfsintf0-30.gtm.corp.microsoft.com</Spn>
+				</Identity>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="CertificateWSTrustBinding_IWSTrustFeb2005Async" binding="tns:CertificateWSTrustBinding_IWSTrustFeb2005Async">
+			<soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/2005/certificatemixed"/>
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/certificatemixed</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="CertificateWSTrustBinding_IWSTrustFeb2005Async1" binding="tns:CertificateWSTrustBinding_IWSTrustFeb2005Async1">
+			<soap12:address location="https://certauth.msft.sts.microsoft.com/adfs/services/trust/2005/certificatetransport"/>
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://certauth.msft.sts.microsoft.com/adfs/services/trust/2005/certificatetransport</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="UserNameWSTrustBinding_IWSTrustFeb2005Async" binding="tns:UserNameWSTrustBinding_IWSTrustFeb2005Async">
+			<soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/2005/usernamemixed"/>
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/usernamemixed</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async" binding="tns:IssuedTokenWSTrustBinding_IWSTrustFeb2005Async">
+			<soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/2005/issuedtokenmixedasymmetricbasic256"/>
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/issuedtokenmixedasymmetricbasic256</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1" binding="tns:IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1">
+			<soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/2005/issuedtokenmixedsymmetricbasic256"/>
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/issuedtokenmixedsymmetricbasic256</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="CertificateWSTrustBinding_IWSTrust13Async" binding="tns:CertificateWSTrustBinding_IWSTrust13Async">
+			<soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/13/certificatemixed"/>
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/certificatemixed</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="UserNameWSTrustBinding_IWSTrust13Async" binding="tns:UserNameWSTrustBinding_IWSTrust13Async">
+			<soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/13/usernamemixed"/>
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/usernamemixed</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="IssuedTokenWSTrustBinding_IWSTrust13Async" binding="tns:IssuedTokenWSTrustBinding_IWSTrust13Async">
+			<soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/13/issuedtokenmixedasymmetricbasic256"/>
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/issuedtokenmixedasymmetricbasic256</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="IssuedTokenWSTrustBinding_IWSTrust13Async1" binding="tns:IssuedTokenWSTrustBinding_IWSTrust13Async1">
+			<soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/13/issuedtokenmixedsymmetricbasic256"/>
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/issuedtokenmixedsymmetricbasic256</wsa10:Address>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+		<wsdl:port name="CustomBinding_IWSTrust13Async" binding="tns:CustomBinding_IWSTrust13Async">
+			<soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport"/>
+			<wsa10:EndpointReference>
+				<wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport</wsa10:Address>
+				<Identity xmlns="http://schemas.xmlsoap.org/ws/2006/02/addressingidentity">
+					<Spn>HOST/adfsintf0-30.gtm.corp.microsoft.com</Spn>
+				</Identity>
+			</wsa10:EndpointReference>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Hello. 

MSSQL JDBC driver, which depends on ADAL4J, would like to support AAD integrated auth on Windows, Linux and MacOS. Since ADAL4J does not support integrated auth yet, this PR implements it. It has been tested on Windows, Linux and MacOS.

Thank you.