### PR TITLE
Fix acquireTokenByRefreshToken with AsymmetricKeyCredential with different audience

### DIFF
--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -873,7 +873,7 @@ public class AuthenticationContext {
                 credential.getClientId(),
                 JwtHelper.buildJwt(credential,
                         this.authenticationAuthority.getSelfSignedJwtAudience()),
-                (String) null, callback);
+                resource, callback);
     }
 
     /**


### PR DESCRIPTION
Previously, the `acquireTokenByRefreshToken` method with a `AsymmetricKeyCredential` did not pass through the `resource` to the delegated method, so it would have the wrong audience if the resource was different than the original the token was created with.