### PR TITLE
Support proxies with authentication

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,48 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+azure-activedirectory-library-for-java incorporates third party material from the projects listed below.
+1.	SSL Socket Client with Tunneling (https://docs.oracle.com/javase/7/docs/technotes/guides/security/jsse/samples/sockets/client/SSLSocketClientWithTunneling.java)
+
+%% SSLSocketClientWithTunneling.java NOTICES, INFORMATION, AND LICENSE BEGIN HERE
+=========================================
+/*
+ *
+ * Copyright (c) 1994, 2004, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * -Redistribution of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * Redistribution in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of Oracle nor the names of
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * This software is provided "AS IS," without a warranty of any
+ * kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
+ * WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
+ * EXCLUDED. SUN MICROSYSTEMS, INC. ("SUN") AND ITS LICENSORS SHALL
+ * NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT
+ * OF USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
+ * DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR
+ * ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT,
+ * SPECIAL, CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER
+ * CAUSED AND REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF
+ * THE USE OF OR INABILITY TO USE THIS SOFTWARE, EVEN IF SUN HAS
+ * BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ *
+ * You acknowledge that this software is not designed, licensed or
+ * intended for use in the design, construction, operation or
+ * maintenance of any nuclear facility.
+ */
+=========================================
+END OF SSLSocketClientWithTunneling.java NOTICES, INFORMATION, AND LICENSE

--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -147,6 +147,24 @@ public class AuthenticationContext {
     }
 
     /**
+     * Sets a Proxy configuration with username/password authentication to be
+     * used by the context for all network communication. The Proxy is set as
+     * a tunneled socket through which direct SSL sockets are open.
+     *
+     * @param host
+     *            the host name of the proxy server
+     * @param port
+     *            the port of the proxy server
+     * @param proxyUsername
+     *            the username to authenticate to the proxy server
+     * @param proxyPassword
+     *            the password to authenticate to the proxy server
+     */
+    public void setProxy(String host, int port, String proxyUsername, String proxyPassword) {
+        setSslSocketFactory(new SSLProxyTunnelSocketFactory(host, port, proxyUsername, proxyPassword));
+    }
+
+    /**
      * Returns SSLSocketFactory configuration object.
      * 
      * @return SSLSocketFactory object

--- a/src/main/java/com/microsoft/aad/adal4j/BasicChallengeHandler.java
+++ b/src/main/java/com/microsoft/aad/adal4j/BasicChallengeHandler.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.aad.adal4j;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.binary.Hex;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * An implementation of the ChallengeHandler that can satisfy a Basic
+ * authentication challenge.
+ */
+public class BasicChallengeHandler implements ChallengeHandler {
+    private AtomicInteger nonceCounter = new AtomicInteger(0);
+    private String username;
+    private String password;
+
+    /**
+     * Creates a BasicChallengeHandler.
+     * @param username the username to authenticate
+     * @param password the password to authenticate
+     */
+    public BasicChallengeHandler(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public String handle(String httpMethod, String uri, List<String> wwwAuthenticate) {
+        String token = username + ":" + password;
+        return "Basic " + Base64.encodeBase64String(token.getBytes());
+    }
+}

--- a/src/main/java/com/microsoft/aad/adal4j/ChallengeHandler.java
+++ b/src/main/java/com/microsoft/aad/adal4j/ChallengeHandler.java
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.aad.adal4j;
+
+import java.util.List;
+
+/**
+ * Authentication challenge Interface that can be implemented by the developer,
+ * used to satisfy an authentication challenge from the server.
+ */
+public interface ChallengeHandler {
+    /**
+     * Answers the challenge with a set of request headers, based on the status code,
+     * response body, and response headers.
+     *
+     *
+     * @param httpMethod the HTTP method to the request URI
+     * @param uri the request uri, or
+     * @param wwwAuthenticate the WWW-Authenticate or Proxy-Authenticate headers
+     * @return the new request Authorization header
+     */
+    String handle(String httpMethod, String uri, List<String> wwwAuthenticate);
+}

--- a/src/main/java/com/microsoft/aad/adal4j/DigestChallengeHandler.java
+++ b/src/main/java/com/microsoft/aad/adal4j/DigestChallengeHandler.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.aad.adal4j;
+
+import org.apache.commons.codec.binary.Hex;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * An implementation of the ChallengeHandler that can satisfy a Digest
+ * authentication challenge.
+ */
+public class DigestChallengeHandler implements ChallengeHandler {
+    private AtomicInteger nonceCounter = new AtomicInteger(0);
+    private String username;
+    private String password;
+
+    /**
+     * Creates a DigestChallengeHandler.
+     * @param username the username to authenticate
+     * @param password the password to authenticate
+     */
+    public DigestChallengeHandler(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public String handle(String httpMethod, String uri, List<String> wwwAuthenticate) {
+        Map<String, String> challenge = null;
+        for (String w : wwwAuthenticate) {
+            if (w.toLowerCase().startsWith("digest")) {
+                challenge = parseChallengeHeader(w);
+                break;
+            }
+        }
+        if (challenge == null) {
+            throw new UnsupportedOperationException("Cannot find WWW-Authenticate / Proxy-Authenticate header with Digest authentication.");
+        }
+
+        String realm = challenge.get("realm");
+        String nonce = challenge.get("nonce");
+        String qop = challenge.get("qop");
+
+        return handleIntern(realm, nonce, qop, httpMethod, uri);
+    }
+
+    private static Map<String, String> parseChallengeHeader(String header) {
+        String maps = header.replaceFirst("[Dd]igest\\ ", "");
+        String[] parts = maps.split(",");
+        Map<String, String> fields = new HashMap<>();
+        for (String part : parts) {
+            String[] keyValuePair = part.trim().split("=", 2);
+            assert keyValuePair.length == 2;
+            fields.put(keyValuePair[0], keyValuePair[1].replaceAll("^\"", "").replaceAll("\"$", ""));
+        }
+        return fields;
+    }
+
+    private String handleIntern(String realm, String nonce, String qop, String httpMethod, String uri) {
+        try {
+            MessageDigest md5 = MessageDigest.getInstance("md5");
+            SecureRandom secureRandom = new SecureRandom();
+            String a1 = Hex.encodeHexString(md5.digest(String.format("%s:%s:%s", username, realm, password).getBytes(StandardCharsets.UTF_8)));
+            String a2 = Hex.encodeHexString(md5.digest(String.format("%s:%s", httpMethod.toUpperCase(), uri).getBytes(StandardCharsets.UTF_8)));
+
+            byte[] cnonceBytes = new byte[16];
+            secureRandom.nextBytes(cnonceBytes);
+            String cnonce = Hex.encodeHexString(cnonceBytes);
+            String response;
+            if (qop == null || qop.isEmpty()) {
+                response = Hex.encodeHexString(md5.digest(String.format("%s:%s:%s", a1, nonce, a2).getBytes(StandardCharsets.UTF_8)));
+                return String.format("Digest username=\"%s\",realm=\"%s\",nonce=\"%s\",uri=\"%s\",cnonce=\"%s\",response=\"%s\"",
+                        username, realm, nonce, uri, cnonce, response);
+            } else {
+                int nc = nonceCounter.incrementAndGet();
+                response = Hex.encodeHexString(md5.digest(String.format("%s:%s:%08X:%s:%s:%s", a1, nonce, nc, cnonce, qop, a2).getBytes(StandardCharsets.UTF_8)));
+                return String.format("Digest username=\"%s\",realm=\"%s\",nonce=\"%s\",uri=\"%s\",cnonce=\"%s\",nc=%08X,response=\"%s\",qop=\"%s\"",
+                        username, realm, nonce, uri, cnonce, nc, response, qop);
+            }
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/microsoft/aad/adal4j/ProxyAuthenticationType.java
+++ b/src/main/java/com/microsoft/aad/adal4j/ProxyAuthenticationType.java
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.aad.adal4j;
+
+/**
+ * Describes the type of authentication for the proxy server.
+ */
+public enum ProxyAuthenticationType {
+    BASIC,
+    DIGEST
+}

--- a/src/main/java/com/microsoft/aad/adal4j/SSLProxyTunnelSocketFactory.java
+++ b/src/main/java/com/microsoft/aad/adal4j/SSLProxyTunnelSocketFactory.java
@@ -1,0 +1,159 @@
+// sample was written based on https://docs.oracle.com/javase/7/docs/technotes/guides/security/jsse/samples/sockets/client/SSLSocketClientWithTunneling.java
+// here is the copyright notice:
+
+/*
+ *
+ * Copyright (c) 1994, 2004, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * -Redistribution of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * Redistribution in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of Oracle nor the names of
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * This software is provided "AS IS," without a warranty of any
+ * kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
+ * WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
+ * EXCLUDED. SUN MICROSYSTEMS, INC. ("SUN") AND ITS LICENSORS SHALL
+ * NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT
+ * OF USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
+ * DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR
+ * ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT,
+ * SPECIAL, CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER
+ * CAUSED AND REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF
+ * THE USE OF OR INABILITY TO USE THIS SOFTWARE, EVEN IF SUN HAS
+ * BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ *
+ * You acknowledge that this software is not designed, licensed or
+ * intended for use in the design, construction, operation or
+ * maintenance of any nuclear facility.
+ */
+
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.aad.adal4j;
+
+import org.apache.commons.codec.binary.Base64;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.util.Scanner;
+
+public class SSLProxyTunnelSocketFactory extends SSLSocketFactory {
+    private SSLSocketFactory defaultFactory;
+
+    private String tunnelHost;
+
+    private int tunnelPort;
+
+    private String proxyUserName;
+
+    private String proxyPassword;
+
+    public SSLProxyTunnelSocketFactory(String proxyHost, int proxyPort,
+                                       String proxyUserName, String proxyPassword) {
+        tunnelHost = proxyHost;
+        tunnelPort = proxyPort;
+        defaultFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+
+        this.proxyUserName = proxyUserName;
+        this.proxyPassword = proxyPassword;
+    }
+
+    public Socket createSocket(String host, int port) throws IOException {
+        return createSocket(null, host, port, true);
+    }
+
+    public Socket createSocket(String host, int port, InetAddress clientHost,
+                               int clientPort) throws IOException {
+        return createSocket(null, host, port, true);
+    }
+
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return createSocket(null, host.getHostName(), port, true);
+    }
+
+    public Socket createSocket(InetAddress address, int port,
+                               InetAddress clientAddress, int clientPort) throws IOException {
+        return createSocket(null, address.getHostName(), port, true);
+    }
+
+    public Socket createSocket(Socket s, String host, int port,
+                               boolean autoClose) throws IOException {
+
+        Socket tunnel = new Socket(tunnelHost, tunnelPort);
+
+        PrintStream out = new PrintStream(tunnel.getOutputStream());
+
+        String token = proxyUserName + ":" + proxyPassword;
+        String authString = "Basic " + Base64.encodeBase64String(token.getBytes());
+
+        out.println("CONNECT " + host + ":" + port + " HTTP/1.1");
+        out.println("User-Agent: Azure-Sdk-For-Java");
+        out.println("Proxy-Authorization: " + authString);
+        out.print("\r\n\r\n");
+
+        out.flush();
+
+
+        InputStream in = tunnel.getInputStream();
+
+        Scanner scanner = new Scanner(in).useDelimiter("\\A");
+        String response = scanner.hasNext() ? scanner.next() : "";
+
+        if (!response.toLowerCase().contains("200 connection established")) {
+            throw new IOException(String.format("Failed to establish tunnel %s:%d. Message: %s",
+                    tunnelHost, tunnelPort, response));
+        }
+
+        SSLSocket result = (SSLSocket) defaultFactory.createSocket(tunnel, host,
+                port, autoClose);
+
+        return result;
+    }
+
+    public String[] getDefaultCipherSuites() {
+        return defaultFactory.getDefaultCipherSuites();
+    }
+
+    public String[] getSupportedCipherSuites() {
+        return defaultFactory.getSupportedCipherSuites();
+    }
+}


### PR DESCRIPTION
Migrated from https://github.com/AzureAD/azure-activedirectory-library-for-java/pull/251 and added authentication challenge supported. 2 built in challenge types are included, Basic and Digest.

The use of Oracle's library is registered and approved by CELA here: https://ossmsft.visualstudio.com/DefaultCollection/Reviews/_workitems/edit/22799

This code has been tested with a basic and a digest proxy to run an end-to-end scenario. Please advise if more unit testing is required.