### PR TITLE
Update NimbusdsOauth2 SDK to 6.5. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>com.nimbusds</groupId>
 			<artifactId>oauth2-oidc-sdk</artifactId>
-			<version>5.64.4</version>
+			<version>6.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/microsoft/aad/adal4j/AdalAuthorizationGrant.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AdalAuthorizationGrant.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.aad.adal4j;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -35,5 +36,5 @@ public interface AdalAuthorizationGrant {
      *
      * @return A map contains the HTTP parameters
      */
-    Map<String, String> toParameters();
+    Map<String, List<String>> toParameters();
 }

--- a/src/main/java/com/microsoft/aad/adal4j/AdalDeviceCodeAuthorizationGrant.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AdalDeviceCodeAuthorizationGrant.java
@@ -23,7 +23,9 @@
 
 package com.microsoft.aad.adal4j;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -59,11 +61,11 @@ public class AdalDeviceCodeAuthorizationGrant implements AdalAuthorizationGrant 
      * @return The map with HTTP parameters.
      */
     @Override
-    public Map<String, String> toParameters() {
-        final Map<String, String> outParams = new LinkedHashMap<>();
-        outParams.put("resource", resource);
-        outParams.put("grant_type", GRANT_TYPE);
-        outParams.put("code", deviceCode.getDeviceCode());
+    public Map<String, List<String>> toParameters() {
+        final Map<String, List<String>> outParams = new LinkedHashMap<>();
+        outParams.put("resource", Collections.singletonList(resource));
+        outParams.put("grant_type", Collections.singletonList(GRANT_TYPE) );
+        outParams.put("code", Collections.singletonList(deviceCode.getDeviceCode()));
 
         return outParams;
     }

--- a/src/main/java/com/microsoft/aad/adal4j/AdalIntegratedAuthorizationGrant.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AdalIntegratedAuthorizationGrant.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.aad.adal4j;
 
+import java.util.List;
 import java.util.Map;
 
 public class AdalIntegratedAuthorizationGrant implements AdalAuthorizationGrant {
@@ -37,7 +38,7 @@ public class AdalIntegratedAuthorizationGrant implements AdalAuthorizationGrant 
     }
 
     @Override
-    public Map<String, String> toParameters() {
+    public Map<String, List<String>> toParameters() {
         return null;
     }
 

--- a/src/main/java/com/microsoft/aad/adal4j/AdalOAuthAuthorizationGrant.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AdalOAuthAuthorizationGrant.java
@@ -23,7 +23,9 @@
 
 package com.microsoft.aad.adal4j;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.nimbusds.oauth2.sdk.AuthorizationGrant;
@@ -34,7 +36,7 @@ import com.nimbusds.oauth2.sdk.AuthorizationGrant;
 class AdalOAuthAuthorizationGrant implements AdalAuthorizationGrant {
 
     private final AuthorizationGrant grant;
-    private final Map<String, String> params;
+    private final Map<String, List<String>> params;
 
     /**
      * 
@@ -45,7 +47,7 @@ class AdalOAuthAuthorizationGrant implements AdalAuthorizationGrant {
         this.grant = grant;
         params = new LinkedHashMap<>();
         if (!StringHelper.isBlank(resource)) {
-            params.put("resource", resource);
+            params.put("resource", Collections.singletonList(resource));
         }
     }
 
@@ -55,20 +57,20 @@ class AdalOAuthAuthorizationGrant implements AdalAuthorizationGrant {
      * @param params
      */
     AdalOAuthAuthorizationGrant(final AuthorizationGrant grant,
-                                final Map<String, String> params) {
+                                final Map<String, List<String>> params) {
         this.grant = grant;
         this.params = params;
     }
 
     @Override
-    public Map<String, String> toParameters() {
+    public Map<String, List<String>> toParameters() {
 
-        final Map<String, String> outParams = new LinkedHashMap<String, String>();
+        final Map<String, List<String>> outParams = new LinkedHashMap<>();
         if (this.params != null) {
             outParams.putAll(this.params);
         }
 
-        outParams.put("scope", "openid");
+        outParams.put("scope", Collections.singletonList("openid"));
         outParams.putAll(grant.toParameters());
         return outParams;
     }
@@ -77,7 +79,7 @@ class AdalOAuthAuthorizationGrant implements AdalAuthorizationGrant {
         return this.grant;
     }
 
-    Map<String, String> getCustomParameters() {
+    Map<String, List<String>> getCustomParameters() {
         return params;
     }
 }

--- a/src/main/java/com/microsoft/aad/adal4j/AdalTokenRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AdalTokenRequest.java
@@ -27,6 +27,7 @@ import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.net.Proxy;
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 
 import com.nimbusds.oauth2.sdk.ErrorObject;
@@ -155,7 +156,7 @@ class AdalTokenRequest {
                 HTTPRequest.Method.POST, this.uri, headerMap, this.proxy,
                 this.sslSocketFactory);
         httpRequest.setContentType(CommonContentTypes.APPLICATION_URLENCODED);
-        final Map<String, String> params = this.grant.toParameters();
+        final Map<String, List<String>> params = this.grant.toParameters();
         httpRequest.setQuery(URLUtils.serializeParameters(params));
         if (this.clientAuth != null) {
             this.clientAuth.applyTo(httpRequest);

--- a/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
+++ b/src/main/java/com/microsoft/aad/adal4j/AuthenticationContext.java
@@ -28,7 +28,9 @@ import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -309,9 +311,9 @@ public class AuthenticationContext {
                                                      final ClientAuthentication clientAuthentication,
                                                      final AuthenticationCallback callback) {
 
-        Map<String, String> params = new HashMap<String, String>();
-        params.put("resource", resource);
-        params.put("requested_token_use", "on_behalf_of");
+        Map<String, List<String>> params = new HashMap<>();
+        params.put("resource", Collections.singletonList(resource));
+        params.put("requested_token_use", Collections.singletonList("on_behalf_of"));
         try {
             AdalOAuthAuthorizationGrant grant = new AdalOAuthAuthorizationGrant(
             new JWTBearerGrant(SignedJWT.parse(userAssertion.getAssertion())), params);
@@ -933,9 +935,9 @@ public class AuthenticationContext {
             final ClientAssertion clientAssertion) {
 
         try {
-            final Map<String, String> map = new HashMap<String, String>();
-            map.put("client_assertion_type", clientAssertion.getAssertionType());
-            map.put("client_assertion", clientAssertion.getAssertion());
+            final Map<String, List<String>> map = new HashMap<>();
+            map.put("client_assertion_type", Collections.singletonList(clientAssertion.getAssertionType()) );
+            map.put("client_assertion", Collections.singletonList(clientAssertion.getAssertion()));
             return PrivateKeyJWT.parse(map);
         }
         catch (final ParseException e) {

--- a/src/main/java/com/microsoft/aad/adal4j/ClientAuthenticationPost.java
+++ b/src/main/java/com/microsoft/aad/adal4j/ClientAuthenticationPost.java
@@ -23,7 +23,9 @@
 
 package com.microsoft.aad.adal4j;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.mail.internet.ContentType;
@@ -43,11 +45,11 @@ class ClientAuthenticationPost extends ClientAuthentication {
         super(method, clientID);
     }
 
-    Map<String, String> toParameters() {
+    Map<String, List<String>> toParameters() {
 
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, List<String>> params = new HashMap<>();
 
-        params.put("client_id", getClientID().getValue());
+        params.put("client_id", Collections.singletonList(getClientID().getValue()));
 
         return params;
     }
@@ -68,7 +70,7 @@ class ClientAuthenticationPost extends ClientAuthentication {
                     "The HTTP Content-Type header must be "
                             + CommonContentTypes.APPLICATION_URLENCODED);
 
-        Map<String, String> params = httpRequest.getQueryParameters();
+        Map<String, List<String>> params = httpRequest.getQueryParameters();
 
         params.putAll(toParameters());
 

--- a/src/main/java/com/microsoft/aad/adal4j/DeviceCodeRequest.java
+++ b/src/main/java/com/microsoft/aad/adal4j/DeviceCodeRequest.java
@@ -30,7 +30,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLSocketFactory;
 import java.net.Proxy;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class DeviceCodeRequest {
@@ -42,9 +45,9 @@ public class DeviceCodeRequest {
         Map<String, String> headers = new HashMap<>(clientDataHeaders);
         headers.put("Accept", "application/json");
 
-        Map<String, String> queryParameters = new HashMap<>();
-        queryParameters.put("client_id", clientId);
-        queryParameters.put("resource", resource);
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("client_id", Collections.singletonList(clientId));
+        queryParameters.put("resource", Collections.singletonList(resource));
 
         url = url + "?" + URLUtils.serializeParameters(queryParameters);
 

--- a/src/main/java/com/microsoft/aad/adal4j/SAML11BearerGrant.java
+++ b/src/main/java/com/microsoft/aad/adal4j/SAML11BearerGrant.java
@@ -23,6 +23,8 @@
 
 package com.microsoft.aad.adal4j;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import com.nimbusds.jose.util.Base64URL;
@@ -42,10 +44,10 @@ class SAML11BearerGrant extends SAML2BearerGrant {
     }
 
     @Override
-    public Map<String, String> toParameters() {
+    public Map<String, List<String>> toParameters() {
 
-        Map<String, String> params = super.toParameters();
-        params.put("grant_type", grantType.getValue());
+        Map<String, List<String>> params = super.toParameters();
+        params.put("grant_type", Collections.singletonList(grantType.getValue()));
         return params;
     }
 }

--- a/src/samples/public-client-app-sample/pom.xml
+++ b/src/samples/public-client-app-sample/pom.xml
@@ -17,22 +17,8 @@
 			<artifactId>adal4j</artifactId>
 			<version>1.6.3</version>
 		</dependency>
-		<dependency>
-			<groupId>com.nimbusds</groupId>
-			<artifactId>oauth2-oidc-sdk</artifactId>
-			<version>5.64.4</version>
-		</dependency>
-		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20090211</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.21</version>
-		</dependency>
-</dependencies>
+	</dependencies>
+
 	<build>
 		<finalName>public-client-username-password-sample</finalName>
 		<plugins>

--- a/src/samples/public-client-device-code-sample/pom.xml
+++ b/src/samples/public-client-device-code-sample/pom.xml
@@ -21,21 +21,6 @@
             <artifactId>adal4j</artifactId>
             <version>1.6.3</version>
         </dependency>
-        <dependency>
-            <groupId>com.nimbusds</groupId>
-            <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>5.64.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20090211</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.21</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/samples/web-app-samples-for-adal4j/pom.xml
+++ b/src/samples/web-app-samples-for-adal4j/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.nimbusds</groupId>
 			<artifactId>oauth2-oidc-sdk</artifactId>
-			<version>5.64.4</version>
+			<version>6.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.json</groupId>

--- a/src/samples/web-app-samples-for-adal4j/src/main/java/com/microsoft/aad/adal4jsample/BasicFilter.java
+++ b/src/samples/web-app-samples-for-adal4j/src/main/java/com/microsoft/aad/adal4jsample/BasicFilter.java
@@ -118,12 +118,12 @@ public class BasicFilter implements Filter {
 
     private void processAuthenticationData(HttpServletRequest httpRequest, String currentUri, String fullUrl)
             throws Throwable {
-        Map<String, String> params = new HashMap();
+        Map<String, List<String>> params = new HashMap<>();
         for (String key : httpRequest.getParameterMap().keySet()) {
-            params.put(key, httpRequest.getParameterMap().get(key)[0]);
+            params.put(key, Collections.singletonList(httpRequest.getParameterMap().get(key)[0]));
         }
         // validate that state in response equals to state in request
-        StateData stateData = validateState(httpRequest.getSession(), params.get(STATE));
+        StateData stateData = validateState(httpRequest.getSession(), params.get(STATE).get(0));
 
         AuthenticationResponse authResponse = AuthenticationResponseParser.parse(new URI(fullUrl), params);
         if (AuthHelper.isAuthenticationSuccessful(authResponse)) {

--- a/src/test/java/com/microsoft/aad/adal4j/AdalOauthAuthorizatonGrantTest.java
+++ b/src/test/java/com/microsoft/aad/adal4j/AdalOauthAuthorizatonGrantTest.java
@@ -26,6 +26,7 @@ package com.microsoft.aad.adal4j;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
@@ -41,7 +42,7 @@ public class AdalOauthAuthorizatonGrantTest {
     @Test
     public void testConstructor() {
         final AdalOAuthAuthorizationGrant grant = new AdalOAuthAuthorizationGrant(null,
-                new HashMap<String, String>());
+                new HashMap<String, List<String>>());
         Assert.assertNotNull(grant);
     }
 
@@ -50,7 +51,7 @@ public class AdalOauthAuthorizatonGrantTest {
         final AdalOAuthAuthorizationGrant grant = new AdalOAuthAuthorizationGrant(
                 new AuthorizationCodeGrant(new AuthorizationCode("grant"),
                         new URI("http://microsoft.com")),
-                (Map<String, String>) null);
+                (Map<String, List<String>>) null);
         Assert.assertNotNull(grant);
         Assert.assertNotNull(grant.toParameters());
     }


### PR DESCRIPTION
Updating to Nimbusds Oauth 2 to address #248 

Nimbusds Oauth2 SDK introduced a breaking change in [v6.0](https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/67cdbfda45659a3e9dcbcc3838871fce990a0b4a/CHANGELOG.txt?at=master&fileviewer=file-view-default) to support multi-valued query parameters. This is a fix for that change. 