### PR TITLE
Added end-of-support to top of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ---
 
 This library, ADAL for Java, will no longer receive new feature improvements. Instead, use the new
-[MSAL4J](https://github.com/AzureAD/microsoft-authentication-library-for-js).
+[MSAL4J](https://github.com/AzureAD/microsoft-authentication-library-for-java).
 
 * If you are starting a new project, you can get started with the
-  [MSAL4J docs](https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki)
+  [MSAL4J docs](https://github.com/AzureAD/microsoft-authentication-library-for-java/wiki)
   for details about the scenarios, usage, and relevant concepts.
 * If your application is using the previous ADAL JavaScript library, you can follow this
   [migration guide](https://docs.microsoft.com/en-us/azure/active-directory/develop/migrate-adal-msal-java)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This library, ADAL for Java, will no longer receive new feature improvements. In
   [MSAL4J docs](https://github.com/AzureAD/microsoft-authentication-library-for-java/wiki)
   for details about the scenarios, usage, and relevant concepts.
 * If your application is using the previous ADAL JavaScript library, you can follow this
-  [migration guide](https://docs.microsoft.com/en-us/azure/active-directory/develop/migrate-adal-msal-java)
+  [migration guide](https://docs.microsoft.com/azure/active-directory/develop/migrate-adal-msal-java)
   to update to MSAL4J.
 * Existing applications relying on ADAL Java will continue to work.
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This library, ADAL for Java, will no longer receive new feature improvements. In
 * If you are starting a new project, you can get started with the
   [MSAL4J docs](https://github.com/AzureAD/microsoft-authentication-library-for-java/wiki)
   for details about the scenarios, usage, and relevant concepts.
-* If your application is using the previous ADAL JavaScript library, you can follow this
+* If your application is using the previous ADAL for Java library, you can follow this
   [migration guide](https://docs.microsoft.com/azure/active-directory/develop/migrate-adal-msal-java)
   to update to MSAL4J.
-* Existing applications relying on ADAL Java will continue to work.
+* Existing applications relying on ADAL for Java will continue to work.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+---
+
+This library, ADAL for Java, will no longer receive new feature improvements. Instead, use the new
+[MSAL4J](https://github.com/AzureAD/microsoft-authentication-library-for-js).
+
+* If you are starting a new project, you can get started with the
+  [MSAL4J docs](https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki)
+  for details about the scenarios, usage, and relevant concepts.
+* If your application is using the previous ADAL JavaScript library, you can follow this
+  [migration guide](https://docs.microsoft.com/en-us/azure/active-directory/develop/migrate-adal-msal-java)
+  to update to MSAL4J.
+* Existing applications relying on ADAL Java will continue to work.
+
+---
+
 # Microsoft Azure Active Directory Authentication Library (ADAL) for Java
 
 `master` branch    | `dev` branch    | Reference Docs


### PR DESCRIPTION
Left the "Update to MSAL4J" section intact - do we want to remove it if it seems redundant? I mostly care that the announcement is at the top of the repo for consistency and maximum impact, I think we can leave the rest intact if needed.